### PR TITLE
Align auth me response typing with backend

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -6,8 +6,9 @@ import type {
     PhoneVerificationRequest,
     RefreshTokenRequest,
     AuthResponse,
-    UserResponseDTO,
+    MeResponse,
     MessageResponse,
+    UserResponseDTO,
 } from "./types/auth.types";
 
 export const authApi = {
@@ -17,7 +18,7 @@ export const authApi = {
 
     // Get current user information
     me: (client: AxiosInstance) =>
-        client.get<UserResponseDTO>("/api/v1/auth/me"),
+        client.get<MeResponse>("/api/v1/auth/me"),
 
     // Refresh access token
     refresh: (client: AxiosInstance, data: RefreshTokenRequest) =>
@@ -26,6 +27,28 @@ export const authApi = {
     // Logout
     logout: (client: AxiosInstance) =>
         client.post<MessageResponse>("/api/v1/auth/logout"),
+};
+
+export const extractUserPayload = (
+    payload: unknown,
+): UserResponseDTO | undefined => {
+    if (!payload) {
+        return undefined;
+    }
+
+    if (typeof payload === "object") {
+        const withUser = payload as { user?: UserResponseDTO };
+        if (withUser.user) {
+            return withUser.user;
+        }
+
+        const withData = payload as { data?: UserResponseDTO };
+        if (withData.data) {
+            return withData.data;
+        }
+    }
+
+    return payload as UserResponseDTO;
 };
 
 export const userApi = {

--- a/frontend/src/api/types/auth.types.ts
+++ b/frontend/src/api/types/auth.types.ts
@@ -34,6 +34,11 @@ export interface AuthResponse {
     expiresIn: number;
 }
 
+export interface MeResponse {
+    success: boolean;
+    user: UserResponseDTO;
+}
+
 export interface UserResponseDTO {
     id: number;
     email: string;

--- a/frontend/src/hooks/use-auth-api.ts
+++ b/frontend/src/hooks/use-auth-api.ts
@@ -1,11 +1,11 @@
 "use client";
 import { useMutation } from "@tanstack/react-query";
 import { useHttpClient } from "@/context/HttpClientProvider";
-import { authApi, userApi } from "@/api/auth";
+import { authApi, extractUserPayload, userApi } from "@/api/auth";
 import { useRouter } from "next/navigation";
 import { toast } from "@/hooks/use-toast";
 import { AUTH_CONFIG } from "@/utils/constants";
-import type { LoginRequest, RegisterRequest } from "@/api/types/auth.types";
+import type { LoginRequest, MeResponse, RegisterRequest } from "@/api/types/auth.types";
 import {EmailVerificationRequest} from "@/types";
 import {useAuth} from "@/hooks/useAuth";
 
@@ -69,7 +69,15 @@ export function useCurrentUser() {
     const client = useHttpClient();
 
     return useMutation({
-        mutationFn: () => authApi.me(client),
+        mutationFn: async (): Promise<MeResponse> => {
+            const response = await authApi.me(client);
+            const user = extractUserPayload(response.data) ?? response.data.user;
+
+            return {
+                success: response.data.success,
+                user,
+            };
+        },
         onError: (error: any) => {
             console.error("Failed to fetch current user:", error);
         },

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -51,3 +51,24 @@ export const useCan = () => {
         userRole: user?.role,
     };
 };
+
+export const useSubscription = () => {
+    const { user, hasPermission } = useAuth();
+
+    const subscriptionStatus = user?.subscriptionStatus;
+    const isActive = subscriptionStatus === 'ACTIVE';
+    const isTrial = subscriptionStatus === 'TRIAL';
+
+    const canReadBooks =
+        isActive ||
+        isTrial ||
+        hasPermission('CAN_READ_BOOKS') ||
+        hasPermission('CAN_READ_PREMIUM_BOOKS');
+
+    return {
+        canReadBooks,
+        needsSubscription: !canReadBooks,
+        isActive,
+        isTrial,
+    };
+};


### PR DESCRIPTION
## Summary
- update auth API typings to reflect the `{ success, user }` response shape from `/auth/me` and add a helper to normalize nested payloads
- normalize AuthContext and auth hooks to extract the nested `user` payload before parsing while keeping fallbacks for legacy structures
- expose a `useSubscription` hook so `AuthGuard` compiles cleanly with the updated types and return the normalized shape from `useCurrentUser`

## Testing
- npm run build *(fails in container: unable to fetch Google Fonts during Next.js build)*
- npx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_e_68cacc997db0832cb139d132b3db1030