### PR TITLE
Expose derived user role metadata to frontend

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/dto/response/UserResponseDTO.java
+++ b/backend/readify/src/main/java/me/remontada/readify/dto/response/UserResponseDTO.java
@@ -28,6 +28,8 @@ public class UserResponseDTO {
 
     private String fullName;
 
+    private String role;
+
     private Set<Permission> permissions;
 
     private Boolean emailVerified;

--- a/backend/readify/src/main/java/me/remontada/readify/model/User.java
+++ b/backend/readify/src/main/java/me/remontada/readify/model/User.java
@@ -102,8 +102,9 @@ public class User {
 
     public boolean isAdmin() {
         return hasPermission(Permission.CAN_CREATE_USERS) ||
+                hasPermission(Permission.CAN_UPDATE_USERS) ||
                 hasPermission(Permission.CAN_DELETE_USERS) ||
-                hasPermission(Permission.CAN_VIEW_ANALYTICS);
+                hasPermission(Permission.CAN_MANAGE_PAYMENTS);
     }
 
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -14,6 +14,30 @@ import type {
     UserRole
 } from '@/types/auth';
 
+const ADMIN_ROLE_PERMISSIONS: Permission[] = [
+    'CAN_CREATE_USERS',
+    'CAN_UPDATE_USERS',
+    'CAN_DELETE_USERS',
+    'CAN_MANAGE_PAYMENTS',
+];
+
+const MODERATOR_ROLE_PERMISSIONS: Permission[] = [
+    'CAN_MODERATE_CONTENT',
+    'CAN_VIEW_ANALYTICS',
+];
+
+const deriveRoleFromPermissions = (permissions: Permission[] = []): UserRole => {
+    if (permissions.some(permission => ADMIN_ROLE_PERMISSIONS.includes(permission))) {
+        return 'ADMIN';
+    }
+
+    if (permissions.some(permission => MODERATOR_ROLE_PERMISSIONS.includes(permission))) {
+        return 'MODERATOR';
+    }
+
+    return 'USER';
+};
+
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const useAuthContext = () => {
@@ -43,6 +67,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         // Backend vraća direktno user objekat, ne u data.data strukturi
         const userData = data.data || data;
 
+        const permissions: Permission[] = Array.isArray(userData.permissions) ? userData.permissions : [];
+        const role = (userData.role as UserRole | undefined) ?? deriveRoleFromPermissions(permissions);
+
         return {
             id: userData.id,
             email: userData.email,
@@ -50,12 +77,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             lastName: userData.lastName,
             phoneNumber: userData.phoneNumber || userData.phone || null,
             avatarUrl: userData.avatarUrl || userData.profileImageUrl || userData.avatar || null,
-            role: userData.role as UserRole,
-            permissions: userData.permissions || [],
+            role,
+            permissions,
             emailVerified: userData.emailVerified || false,
             phoneVerified: userData.phoneVerified || false,
             createdAt: userData.createdAt,
-            updatedAt: userData.updatedAt,
+            updatedAt: userData.updatedAt || userData.lastLoginAt || userData.createdAt,
             subscriptionStatus: userData.subscriptionStatus || 'TRIAL',
             trialEndsAt: userData.trialEndsAt,
         };


### PR DESCRIPTION
## Summary
- derive canonical user roles from permission sets in the backend mapper and DTO
- align admin detection with the new mapping and include the role field in responses
- rely on the supplied role on the frontend while deriving a safe fallback from permissions

