### PR TITLE
Align book response envelopes with canonical data key

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/controller/BookController.java
+++ b/backend/readify/src/main/java/me/remontada/readify/controller/BookController.java
@@ -197,7 +197,7 @@ public class BookController {
             response.put("message", "Book created successfully");
             response.put("bookId", createdBook.getId());
 
-            response.put("book", BookMapper.toResponseDTO(createdBook));
+            response.put("data", BookMapper.toResponseDTO(createdBook));
 
 
             return ResponseEntity.ok(response);
@@ -241,7 +241,7 @@ public class BookController {
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
             response.put("message", "Book updated successfully");
-            response.put("book", BookMapper.toResponseDTO(updatedBook));
+            response.put("data", BookMapper.toResponseDTO(updatedBook));
 
             return ResponseEntity.ok(response);
 

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth, useCan,useSubscription} from '@/hooks/useAuth';
+import { useAuth, useCan, useSubscription } from '@/hooks/useAuth';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/hooks/use-books.ts
+++ b/frontend/src/hooks/use-books.ts
@@ -106,7 +106,7 @@ export function useCreateBook() {
             try {
 
                 // Backend BookController očekuje Map<String, Object>
-                const bookData = {
+                const bookData: CreateBookRequest = {
                     title: data.title,
                     author: data.author,
                     description: data.description,
@@ -120,13 +120,14 @@ export function useCreateBook() {
                 };
 
                 // Prvi API poziv - kreiranje knjige
-                const bookResponse = await client.post('/api/v1/books', bookData);
+                const bookResponse = await booksApi.createBook(client, bookData);
+                const payload = bookResponse.data;
 
-                if (!bookResponse.data.success) {
-                    throw new Error(bookResponse.data.message || 'Failed to create book');
+                if (!payload.success) {
+                    throw new Error(payload.message || 'Failed to create book');
                 }
 
-                const createdBookId = bookResponse.data.bookId || bookResponse.data.book?.id;
+                const createdBookId = payload.data?.id;
 
                 if (!createdBookId) {
                     throw new Error('Book created but no ID returned');
@@ -152,7 +153,7 @@ export function useCreateBook() {
                     }
                 }
 
-                return bookResponse.data;
+                return payload;
             } catch (error) {
                 console.error('Create book error:', error);
                 throw error;
@@ -163,7 +164,7 @@ export function useCreateBook() {
 
             toast({
                 title: "Uspešno!",
-                description: `Knjiga "${data.book?.title || 'Nova knjiga'}" je uspešno kreirana.`,
+                description: `Knjiga "${data.data?.title || 'Nova knjiga'}" je uspešno kreirana.`,
                 variant: "default",
             });
         },
@@ -182,9 +183,9 @@ export function useUpdateBook() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: async ({ id, data }: { id: number; data: any }) => {
+        mutationFn: async ({ id, data }: { id: number; data: UpdateBookRequest }) => {
             // Backend prima Map<String, Object> format
-            const updateData: any = {};
+            const updateData: UpdateBookRequest = {};
 
             // Dodaj samo polja koja su promenjena
             if (data.title !== undefined) updateData.title = data.title;
@@ -198,7 +199,7 @@ export function useUpdateBook() {
             if (data.isPremium !== undefined) updateData.isPremium = data.isPremium;
             if (data.isAvailable !== undefined) updateData.isAvailable = data.isAvailable;
 
-            const response = await client.put(`/api/v1/books/${id}`, updateData);
+            const response = await booksApi.updateBook(client, id, updateData);
             return response.data;
         },
         onSuccess: (data, variables) => {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -51,3 +51,23 @@ export const useCan = () => {
         userRole: user?.role,
     };
 };
+
+export const useSubscription = () => {
+    const { user, hasPermission } = useAuth();
+
+    const subscriptionStatus = user?.subscriptionStatus ?? null;
+    const isActive = subscriptionStatus === 'ACTIVE';
+    const isTrial = subscriptionStatus === 'TRIAL';
+    const canReadPremiumBooks = hasPermission ? hasPermission('CAN_READ_PREMIUM_BOOKS') : false;
+    const canReadBooks = !!user && (canReadPremiumBooks || isActive || isTrial);
+    const needsSubscription = !canReadBooks;
+
+    return {
+        subscriptionStatus,
+        trialEndsAt: user?.trialEndsAt ?? null,
+        canReadBooks,
+        needsSubscription,
+        isActive,
+        isTrial,
+    };
+};


### PR DESCRIPTION
## Summary
- update BookController create/update responses to place the book DTO under the canonical `data` key
- adjust frontend book hooks to consume the `data` envelope via typed API helpers and refresh related toasts
- add a `useSubscription` hook so AuthGuard can compile while relying on the canonical payload shape

