### PR TITLE
Fix authentication principal to expose user email

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/security/JwtAuthenticationFilter.java
+++ b/backend/readify/src/main/java/me/remontada/readify/security/JwtAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 MyUserDetails userDetails = new MyUserDetails(user);
 
                 UsernamePasswordAuthenticationToken authToken =
-                        new UsernamePasswordAuthenticationToken(user, null, userDetails.getAuthorities());
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/backend/readify/src/main/java/me/remontada/readify/security/MyUserDetails.java
+++ b/backend/readify/src/main/java/me/remontada/readify/security/MyUserDetails.java
@@ -6,11 +6,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.security.Principal;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class MyUserDetails implements UserDetails {
+public class MyUserDetails implements UserDetails, Principal {
 
     private final User user;
 
@@ -38,6 +39,11 @@ public class MyUserDetails implements UserDetails {
     @Override
     public String getUsername() {
         return user.getEmail();
+    }
+
+    @Override
+    public String getName() {
+        return getUsername();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure `MyUserDetails` implements `Principal` and returns the user email as the principal name
- update the JWT authentication filter to store `MyUserDetails` as the authentication principal so controllers receive the email via `Authentication#getName`
