### PR TITLE
Fix duplicate category select keys on new book page

### DIFF
--- a/frontend/src/components/admin/CreateBookForm.tsx
+++ b/frontend/src/components/admin/CreateBookForm.tsx
@@ -221,7 +221,7 @@ export function CreateBookForm() {
                                             Popularne kategorije
                                         </p>
                                         {POPULAR_CATEGORIES.map(category => (
-                                            <SelectItem key={category} value={category}>
+                                            <SelectItem key={`popular-${category}`} value={category}>
                                                 {category}
                                             </SelectItem>
                                         ))}
@@ -233,7 +233,7 @@ export function CreateBookForm() {
                                             Sve kategorije
                                         </p>
                                         {BOOK_CATEGORIES.map(category => (
-                                            <SelectItem key={category} value={category}>
+                                            <SelectItem key={`all-${category}`} value={category}>
                                                 {category}
                                             </SelectItem>
                                         ))}


### PR DESCRIPTION
## Summary
- ensure the category select items use unique React keys for popular and all category sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd24ec834832caecf56d87bf5d7bf