### PR TITLE
Increase PDF limit and refresh admin styling

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/service/LocalFileStorageService.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/LocalFileStorageService.java
@@ -36,8 +36,8 @@ public class LocalFileStorageService implements FileStorageService {
     @Value("${app.storage.local.covers-dir:covers}")
     private String coversDir;
 
-    // Maksimalna veličina fajla (50MB default)
-    @Value("${app.storage.max-file-size:52428800}")
+    // Maksimalna veličina fajla (70MB default)
+    @Value("${app.storage.max-file-size:73400320}")
     private long maxFileSize;
 
     private Path booksPath;

--- a/backend/readify/src/main/resources/application.properties
+++ b/backend/readify/src/main/resources/application.properties
@@ -52,17 +52,17 @@ app.storage.local.books-dir=books
 app.storage.local.covers-dir=covers
 
 # File Size Limits
-app.storage.max-file-size=52428800
-# 50MB max za sve fajlove
-app.storage.max-pdf-size=52428800
-# 50MB max za PDF
+app.storage.max-file-size=73400320
+# 70MB max za sve fajlove
+app.storage.max-pdf-size=73400320
+# 70MB max za PDF
 app.storage.max-image-size=5242880
 # 5MB max za cover slike
 
 # Multipart File Upload Configuration
 spring.servlet.multipart.enabled=true
-spring.servlet.multipart.max-file-size=50MB
-spring.servlet.multipart.max-request-size=55MB
+spring.servlet.multipart.max-file-size=70MB
+spring.servlet.multipart.max-request-size=80MB
 spring.servlet.multipart.resolve-lazily=false
 # File se ucitava odmah, ne lazy
 

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -9,12 +9,10 @@ import {
     BarChart3,
     Settings,
     Upload,
-    Library,
     DollarSign,
     Shield,
     LogOut,
-    Menu,
-    X
+    Menu
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -89,27 +87,27 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     );
 
     const SidebarContent = () => (
-        <>
+        <div className="flex h-full flex-col">
             {/* Admin Header */}
-            <div className="px-4 py-6">
-                <div className="flex items-center gap-3">
-                    <div className="p-2 bg-reading-accent/10 rounded-lg">
-                        <Shield className="w-6 h-6 text-reading-accent" />
+            <div className="px-5 pb-6 pt-8">
+                <div className="flex items-center gap-3 rounded-2xl bg-reading-accent/10 p-4">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-reading-accent text-white shadow">
+                        <Shield className="h-6 w-6" />
                     </div>
                     <div>
-                        <h2 className={cn(dt.typography.cardTitle)}>Admin Panel</h2>
-                        <p className={cn(dt.typography.muted)}>
+                        <h2 className="text-lg font-semibold text-reading-text">Admin panel</h2>
+                        <p className="text-sm text-reading-text/70">
                             {user?.firstName} {user?.lastName}
                         </p>
                     </div>
                 </div>
             </div>
 
-            <Separator />
+            <Separator className="border-reading-accent/10" />
 
             {/* Navigation */}
-            <ScrollArea className="flex-1 px-2 py-4">
-                <nav className="space-y-1">
+            <ScrollArea className="flex-1 px-3 py-6">
+                <nav className="space-y-2">
                     {filteredNavItems.map((item) => {
                         const isActive = pathname === item.href ||
                             (item.href !== '/admin' && pathname.startsWith(item.href));
@@ -120,46 +118,54 @@ export function AdminLayout({ children }: AdminLayoutProps) {
                                 href={item.href}
                                 onClick={() => setMobileOpen(false)}
                                 className={cn(
-                                    "flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors",
+                                    "group flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-all", 
+                                    "hover:bg-reading-accent/10 hover:text-reading-text",
                                     isActive
-                                        ? "bg-reading-accent text-white"
-                                        : "text-reading-text hover:bg-book-green-100"
+                                        ? "bg-reading-accent text-white shadow"
+                                        : "text-reading-text/80"
                                 )}
                             >
-                                {item.icon}
-                                <span className="font-medium">{item.title}</span>
+                                <span className={cn(
+                                    "flex h-9 w-9 items-center justify-center rounded-lg border border-transparent",
+                                    isActive
+                                        ? "bg-white/20"
+                                        : "bg-reading-accent/5 text-reading-text/70 group-hover:border-reading-accent/30"
+                                )}>
+                                    {item.icon}
+                                </span>
+                                <span className="font-semibold tracking-wide">{item.title}</span>
                             </Link>
                         );
                     })}
                 </nav>
             </ScrollArea>
 
-            <Separator />
+            <Separator className="border-reading-accent/10" />
 
             {/* Logout Button */}
-            <div className="p-4">
+            <div className="px-5 pb-8 pt-6">
                 <Button
                     onClick={logout}
                     variant="ghost"
-                    className="w-full justify-start gap-3 text-reading-text hover:bg-book-green-100"
+                    className="w-full justify-start gap-3 rounded-xl bg-reading-accent/5 px-4 py-3 text-reading-text transition-colors hover:bg-reading-accent/15"
                 >
-                    <LogOut className="w-5 h-5" />
-                    <span>Odjavi se</span>
+                    <LogOut className="h-5 w-5" />
+                    <span className="font-semibold">Odjavi se</span>
                 </Button>
             </div>
-        </>
+        </div>
     );
 
     return (
-        <div className="flex h-screen bg-reading-background">
+        <div className="flex min-h-screen bg-gradient-to-br from-reading-background via-white to-book-green-50 text-reading-text">
             {/* Desktop Sidebar */}
-            <aside className="hidden lg:flex lg:flex-col w-64 bg-reading-surface border-r border-reading-accent/10">
+            <aside className="hidden w-72 flex-col border-r border-reading-accent/10 bg-white/90 shadow-xl backdrop-blur lg:flex">
                 <SidebarContent />
             </aside>
 
             {/* Mobile Sidebar */}
             <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-                <SheetContent side="left" className="w-64 p-0 bg-reading-surface">
+                <SheetContent side="left" className="w-72 border-none bg-white/95 p-0 shadow-xl">
                     <SidebarContent />
                 </SheetContent>
             </Sheet>
@@ -167,8 +173,8 @@ export function AdminLayout({ children }: AdminLayoutProps) {
             {/* Main Content */}
             <div className="flex-1 flex flex-col overflow-hidden">
                 {/* Top Bar */}
-                <header className="h-16 bg-reading-surface border-b border-reading-accent/10 px-4 lg:px-6">
-                    <div className="h-full flex items-center justify-between">
+                <header className="h-20 border-b border-reading-accent/10 bg-white/80 px-4 shadow-sm backdrop-blur lg:px-8">
+                    <div className="flex h-full items-center justify-between">
                         {/* Mobile Menu Button */}
                         <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
                             <SheetTrigger asChild>
@@ -183,28 +189,32 @@ export function AdminLayout({ children }: AdminLayoutProps) {
                         </Sheet>
 
                         {/* Page Title */}
-                        <h1 className={cn(dt.typography.sectionTitle, "hidden lg:block")}>
-                            {navItems.find(item => pathname.startsWith(item.href))?.title || 'Dashboard'}
-                        </h1>
+                        <div className="hidden flex-col gap-1 lg:flex">
+                            <span className="text-xs uppercase tracking-[0.2em] text-reading-text/60">Readify admin</span>
+                            <h1 className={cn(dt.typography.sectionTitle)}>
+                                {navItems.find(item => pathname.startsWith(item.href))?.title || 'Dashboard'}
+                            </h1>
+                        </div>
 
                         {/* User Info */}
                         <div className="flex items-center gap-4">
-                            <span className={cn(dt.typography.muted)}>
-                                {user?.role}
-                            </span>
-                            <div className="w-10 h-10 bg-reading-accent/10 rounded-full flex items-center justify-center">
-                                <span className="text-reading-accent font-semibold">
-                                    {user?.firstName?.[0]}{user?.lastName?.[0]}
-                                </span>
+                            <div className="hidden flex-col text-right text-sm text-reading-text/70 sm:flex">
+                                <span className="font-semibold text-reading-text">{user?.firstName} {user?.lastName}</span>
+                                <span className="text-xs uppercase tracking-widest text-reading-text/60">{user?.role}</span>
+                            </div>
+                            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-reading-accent/15 text-lg font-semibold text-reading-accent shadow-inner">
+                                {user?.firstName?.[0]}{user?.lastName?.[0]}
                             </div>
                         </div>
                     </div>
                 </header>
 
                 {/* Page Content */}
-                <main className="flex-1 overflow-auto">
-                    <div className={cn(dt.layouts.pageContainer)}>
-                        {children}
+                <main className="flex-1 overflow-auto px-4 pb-10 pt-6 lg:px-8 lg:pt-8">
+                    <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+                        <div className="w-full rounded-3xl border border-reading-accent/10 bg-white/85 p-6 shadow-sm backdrop-blur">
+                            {children}
+                        </div>
                     </div>
                 </main>
             </div>

--- a/frontend/src/components/admin/CreateBookForm.tsx
+++ b/frontend/src/components/admin/CreateBookForm.tsx
@@ -396,7 +396,7 @@ export function CreateBookForm() {
                                     className="hidden"
                                 />
                                 <p className={cn(dt.typography.muted, "mt-2")}>
-                                    Maksimalno 50MB
+                                    Maksimalno 70MB
                                 </p>
                                 {watch('pdfFile') && (
                                     <Badge variant="secondary" className="mt-3">

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default select-none items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-reading-text outline-none transition-colors hover:bg-reading-accent/10 focus:bg-reading-accent/15 data-[state=open]:bg-reading-accent/20 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-reading-accent/20 bg-reading-surface/95 p-1 text-reading-text shadow-xl backdrop-blur data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-xl border border-reading-accent/20 bg-reading-surface/95 p-1 text-reading-text shadow-xl backdrop-blur",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className
       )}
@@ -84,7 +84,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-reading-text outline-none transition-colors hover:bg-reading-accent/10 focus:bg-reading-accent/15 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -100,7 +100,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-lg py-2 pl-10 pr-3 text-sm font-medium text-reading-text outline-none transition-colors hover:bg-reading-accent/10 focus:bg-reading-accent/15 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-lg py-2 pl-10 pr-3 text-sm font-medium text-reading-text outline-none transition-colors hover:bg-reading-accent/10 focus:bg-reading-accent/15 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -148,7 +148,7 @@ const DropdownMenuLabel = React.forwardRef<
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
+      "px-3 py-2 text-xs font-semibold uppercase tracking-widest text-reading-text/60",
       inset && "pl-8",
       className
     )}
@@ -163,7 +163,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-reading-accent/20", className)}
     {...props}
   />
 ))

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -19,14 +19,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between whitespace-nowrap rounded-lg border border-reading-accent/30 bg-reading-surface/90 px-3 py-2 text-sm font-medium text-reading-text shadow-sm backdrop-blur data-[placeholder]:text-reading-text/50 focus:outline-none focus:ring-2 focus:ring-reading-accent/40 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 text-reading-text/60 transition-transform duration-200 data-[state=open]:rotate-180" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-xl border border-reading-accent/20 bg-reading-surface/95 text-reading-text shadow-xl backdrop-blur data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-lg px-3 py-2 text-sm font-medium outline-none transition-colors hover:bg-reading-accent/10 focus:bg-reading-accent/15 focus:text-reading-text data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- raise backend storage configuration to allow 70MB PDF uploads and surface the higher limit in the create-book form
- refresh the admin layout with a brighter sidebar, header, and content container styling
- tighten select and dropdown UI styling so admin menus and filters are clearly legible

## Testing
- npm run lint
- ./mvnw -q test *(fails: cannot reach Maven Central to resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe8043980832c83805517370d02ca