### PR TITLE
Fix admin book cover placeholder image

### DIFF
--- a/frontend/public/book-placeholder.svg
+++ b/frontend/public/book-placeholder.svg
@@ -1,0 +1,8 @@
+<svg width="48" height="64" viewBox="0 0 48 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="48" height="64" rx="6" fill="#F3F4F6"/>
+  <rect x="10" y="14" width="28" height="36" rx="3" fill="#E5E7EB"/>
+  <rect x="14" y="20" width="20" height="4" rx="1.5" fill="#CBD5F5"/>
+  <rect x="14" y="28" width="20" height="4" rx="1.5" fill="#D1D5DB"/>
+  <rect x="14" y="36" width="12" height="4" rx="1.5" fill="#D1D5DB"/>
+  <path d="M36 16V46" stroke="#CBD5F5" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useState } from 'react';
+import { SyntheticEvent, useState } from 'react';
 import Link from 'next/link';
 import {
     Plus,
@@ -50,6 +50,8 @@ import { useCan } from '@/hooks/useAuth';
 import { BookResponseDTO } from '@/api/types/books.types';
 import { dt } from '@/lib/design-tokens';
 import { cn } from '@/lib/utils';
+
+const FALLBACK_COVER_IMAGE = '/book-placeholder.svg';
 
 export default function AdminBooksPage() {
     const { can } = useCan();
@@ -225,25 +227,29 @@ export default function AdminBooksPage() {
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>
-                                        {filteredBooks.map((book) => (
-                                            <TableRow key={book.id}>
-                                                {/* Cover */}
-                                                <TableCell>
-                                                    {resolveCoverUrl(book) ? (
-                                                        <img
-                                                            src={resolveCoverUrl(book) ?? undefined}
-                                                            alt={book.title}
-                                                            className="w-12 h-16 object-cover rounded"
-                                                            onError={(e) => {
-                                                                (e.target as any).src = 'https://via.placeholder.com/48x64';
-                                                            }}
-                                                        />
-                                                    ) : (
-                                                        <div className="w-12 h-16 bg-reading-accent/10 rounded flex items-center justify-center">
-                                                            <BookOpen className="w-6 h-6 text-reading-accent/40" />
-                                                        </div>
-                                                    )}
-                                                </TableCell>
+                                        {filteredBooks.map((book) => {
+                                            const coverUrl = resolveCoverUrl(book);
+
+                                            return (
+                                                <TableRow key={book.id}>
+                                                    {/* Cover */}
+                                                    <TableCell>
+                                                        {coverUrl ? (
+                                                            <img
+                                                                src={coverUrl}
+                                                                alt={book.title}
+                                                                className="w-12 h-16 object-cover rounded"
+                                                                onError={(event: SyntheticEvent<HTMLImageElement>) => {
+                                                                    event.currentTarget.onerror = null;
+                                                                    event.currentTarget.src = FALLBACK_COVER_IMAGE;
+                                                                }}
+                                                            />
+                                                        ) : (
+                                                            <div className="w-12 h-16 bg-reading-accent/10 rounded flex items-center justify-center">
+                                                                <BookOpen className="w-6 h-6 text-reading-accent/40" />
+                                                            </div>
+                                                        )}
+                                                    </TableCell>
 
                                                 {/* Naslov */}
                                                 <TableCell>
@@ -353,7 +359,8 @@ export default function AdminBooksPage() {
                                                     </DropdownMenu>
                                                 </TableCell>
                                             </TableRow>
-                                        ))}
+                                        );
+                                        })}
                                     </TableBody>
                                 </Table>
                             </div>


### PR DESCRIPTION
- add a local book cover placeholder asset that can be used when remote covers fail to load
- update the admin books table to reuse the resolved cover URL and swap to the local placeholder when an image error occurs
