### PR TITLE
Allow public access to cover images

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/config/SecurityConfig.java
+++ b/backend/readify/src/main/java/me/remontada/readify/config/SecurityConfig.java
@@ -72,6 +72,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/popular").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/top-rated").permitAll()
 
+                        // Public file access (book covers)
+                        .requestMatchers(HttpMethod.GET, "/api/v1/files/covers/**").permitAll()
+
                         // Book reading
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/{id}/read").authenticated()
 

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -49,6 +49,7 @@ import { useCan } from '@/hooks/useAuth';
 import { BookResponseDTO } from '@/api/types/books.types';
 import { dt } from '@/lib/design-tokens';
 import { cn } from '@/lib/utils';
+import { resolveApiFileUrl } from '@/lib/asset-utils';
 
 const FALLBACK_COVER_IMAGE = '/book-placeholder.svg';
 
@@ -84,41 +85,7 @@ export default function AdminBooksPage() {
         }
     };
 
-    const resolveCoverUrl = (book: BookResponseDTO) => {
-        const rawCoverUrl = book.coverImageUrl?.trim();
-
-        if (!rawCoverUrl) {
-            return null;
-        }
-
-        if (/^https?:\/\//i.test(rawCoverUrl)) {
-            return rawCoverUrl;
-        }
-
-        const normalizedPath = rawCoverUrl.startsWith('/') ? rawCoverUrl : `/${rawCoverUrl}`;
-        const candidateBases: string[] = [];
-
-        if (process.env.NEXT_PUBLIC_API_URL) {
-            candidateBases.push(process.env.NEXT_PUBLIC_API_URL);
-        }
-
-        if (typeof window !== 'undefined') {
-            candidateBases.push(window.location.origin);
-        }
-
-        candidateBases.push('http://localhost:8080');
-
-        for (const base of candidateBases) {
-            try {
-                const formattedBase = base.endsWith('/') ? base : `${base}/`;
-                return new URL(normalizedPath, formattedBase).toString();
-            } catch (error) {
-                console.warn('Failed to resolve cover URL with base', base, error);
-            }
-        }
-
-        return normalizedPath;
-    };
+    const resolveCoverUrl = (book: BookResponseDTO) => resolveApiFileUrl(book.coverImageUrl);
 
     return (
         <AdminLayout>

--- a/frontend/src/components/admin/EditBookForm.tsx
+++ b/frontend/src/components/admin/EditBookForm.tsx
@@ -31,6 +31,7 @@ import { BOOK_CATEGORIES, POPULAR_CATEGORIES } from '@/utils/book-categories';
 import { BookResponseDTO } from '@/api/types/books.types';
 import { dt } from '@/lib/design-tokens';
 import { cn } from '@/lib/utils';
+import { resolveApiFileUrl } from '@/lib/asset-utils';
 
 // Validation schema za edit (sva polja su opciona jer šaljemo samo promenjene)
 const editBookSchema = z.object({
@@ -195,10 +196,7 @@ export function EditBookForm({ book }: EditBookFormProps) {
 
     const getCoverUrl = () => {
         if (previewUrl) return previewUrl;
-        if (book.coverImageUrl) {
-            return `${process.env.NEXT_PUBLIC_API_URL}/api/v1/files/covers/${book.id}`;
-        }
-        return null;
+        return resolveApiFileUrl(book.coverImageUrl);
     };
 
     return (

--- a/frontend/src/components/landing/BookCarousel.tsx
+++ b/frontend/src/components/landing/BookCarousel.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
 import { useAuth } from '@/hooks/useAuth';
 import { dt } from '@/lib/design-tokens';
+import { resolveApiFileUrl } from '@/lib/asset-utils';
 
 interface Book {
     id: number;
@@ -83,7 +84,7 @@ export const BookCarousel = ({ title, books, viewAllHref }: BookCarouselProps) =
                                 <CardContent className="p-0 h-full flex flex-col">
                                     <div className="relative">
                                         <img
-                                            src={book.coverImageUrl}
+                                            src={resolveApiFileUrl(book.coverImageUrl) ?? book.coverImageUrl}
                                             alt={book.title}
                                             className="w-full h-48 sm:h-56 object-cover rounded-t-lg"
                                         />

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
 import { dt } from '@/lib/design-tokens';
+import { resolveApiFileUrl } from '@/lib/asset-utils';
 
 interface FeaturedBook {
     id: number;
@@ -110,7 +111,7 @@ export const HeroSection = ({ featuredBook }: HeroSectionProps) => {
                                 <Card className={`${dt.components.bookCard} max-w-sm mx-auto lg:max-w-none`}>
                                     <div className="relative">
                                         <img
-                                            src={featuredBook.coverImageUrl}
+                                            src={resolveApiFileUrl(featuredBook.coverImageUrl) ?? featuredBook.coverImageUrl}
                                             alt={featuredBook.title}
                                             className="w-full h-96 object-cover rounded-t-lg"
                                         />

--- a/frontend/src/lib/asset-utils.ts
+++ b/frontend/src/lib/asset-utils.ts
@@ -1,0 +1,43 @@
+import { API_CONFIG } from '@/utils/constants';
+
+const ENV_API_BASE_URL = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+const DEFAULT_API_BASE_URL = ENV_API_BASE_URL && ENV_API_BASE_URL.length > 0
+    ? ENV_API_BASE_URL
+    : API_CONFIG.BASE_URL;
+
+const API_BASE_URL = DEFAULT_API_BASE_URL.replace(/\/?$/, '');
+
+const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
+
+const normalizePath = (path: string) => path.replace(/\\/g, '/');
+
+export function resolveApiFileUrl(path?: string | null): string | null {
+    if (!path) {
+        return null;
+    }
+
+    const trimmedPath = normalizePath(path.trim());
+
+    if (trimmedPath.length === 0) {
+        return null;
+    }
+
+    if (ABSOLUTE_URL_REGEX.test(trimmedPath)) {
+        return trimmedPath;
+    }
+
+    const normalizedPath = trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
+
+    if (!API_BASE_URL) {
+        return normalizedPath;
+    }
+
+    try {
+        return new URL(normalizedPath, API_BASE_URL.endsWith('/') ? API_BASE_URL : `${API_BASE_URL}/`).toString();
+    } catch (error) {
+        console.warn('Failed to build file URL', { path: normalizedPath, baseUrl: API_BASE_URL, error });
+        return `${API_BASE_URL}${normalizedPath}`;
+    }
+}
+


### PR DESCRIPTION
- permit unauthenticated GET access to `/api/v1/files/covers/**` so browsers can fetch stored cover images without JWTs

