### PR TITLE
Improve hero cover display and contrast

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -123,7 +123,7 @@
     border-color: rgba(228, 179, 76, 0.4);
   }
   .hover\:bg-book-green-100:hover {
-    background-color: rgba(84, 166, 255, 0.16);
+    background-color: #dcfce7;
   }
   .hover\:text-reading-accent:hover {
     color: #E4B34C;

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -151,7 +151,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     );
 
     return (
-        <div className="flex min-h-screen bg-reading-background text-reading-text">
+        <div className="flex min-h-screen bg-reading-surface text-reading-text">
             {/* Desktop Sidebar */}
             <aside className="hidden w-72 flex-col border-r border-reading-accent/10 bg-white/90 shadow-xl backdrop-blur lg:flex">
                 <SidebarContent />

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ArrowUpRight, BookOpen, Clock3, ShieldCheck, Sparkles, Users } from 'lucide-react';
+import { ArrowUpRight, BookOpen, Clock3, Sparkles, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { dt } from '@/lib/design-tokens';
@@ -134,15 +134,17 @@ export const HeroSection = ({ topBook, isAuthenticated, isBooksLoading }: HeroSe
                                     </div>
                                 ) : topBook ? (
                                     <div className="space-y-6">
-                                        <div className="overflow-hidden rounded-3xl shadow-xl">
+                                        <div className="relative overflow-hidden rounded-3xl bg-library-parchment/95 p-4 shadow-xl">
                                             {coverImageUrl ? (
-                                                <img
-                                                    src={coverImageUrl}
-                                                    alt={topBook.title}
-                                                    className="h-64 w-full object-cover"
-                                                />
+                                                <div className="flex min-h-[18rem] items-center justify-center sm:min-h-[22rem]">
+                                                    <img
+                                                        src={coverImageUrl}
+                                                        alt={topBook.title}
+                                                        className="max-h-[18rem] w-auto object-contain drop-shadow-xl sm:max-h-[22rem]"
+                                                    />
+                                                </div>
                                             ) : (
-                                                <div className="flex h-64 w-full items-center justify-center rounded-3xl bg-library-azure/20 text-reading-text/60">
+                                                <div className="flex min-h-[18rem] w-full items-center justify-center rounded-2xl bg-library-azure/15 text-reading-text/60 sm:min-h-[22rem]">
                                                     Nema dostupne naslovnice
                                                 </div>
                                             )}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -169,8 +169,8 @@ export const Navbar = () => {
                                     )}
 
                                     <div className="mb-6">
-                                        <div className="flex items-center gap-2 rounded-full border border-reading-accent/10 bg-reading-background px-4 py-2">
-                                            <Search className="h-4 w-4 text-reading-text/50" />
+                                        <div className="flex items-center gap-2 rounded-full border border-reading-accent/10 bg-reading-surface px-4 py-2">
+                                            <Search className="h-4 w-4 text-reading-text/70" />
                                             <Input
                                                 placeholder="Pretraži knjige"
                                                 className="h-auto border-none bg-transparent p-0 text-sm focus-visible:ring-0"
@@ -242,8 +242,8 @@ export const Navbar = () => {
                         </nav>
 
                         <div className="ml-auto flex items-center gap-4">
-                            <div className="hidden md:flex w-64 items-center gap-2 rounded-full border border-reading-accent/10 bg-reading-background px-4 py-2">
-                                <Search className="h-4 w-4 text-reading-text/50" />
+                            <div className="hidden md:flex w-64 items-center gap-2 rounded-full border border-reading-accent/10 bg-reading-surface px-4 py-2">
+                                <Search className="h-4 w-4 text-reading-text/70" />
                                 <Input
                                     placeholder="Pretraži knjige"
                                     className="h-auto border-none bg-transparent p-0 text-sm focus-visible:ring-0"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -31,6 +31,20 @@ module.exports = {
                     contrast: '#F5F1E6',
                     highlight: '#54A6FF',
                 },
+                book: {
+                    green: {
+                        50: '#f0fdf4',
+                        100: '#dcfce7',
+                        200: '#bbf7d0',
+                        300: '#86efac',
+                        400: '#4ade80',
+                        500: '#22c55e',
+                        600: '#16a34a',
+                        700: '#15803d',
+                        800: '#166534',
+                        900: '#14532d',
+                    },
+                },
             },
             fontFamily: {
                 display: ['var(--font-playfair)', 'Playfair Display', 'serif'],


### PR DESCRIPTION
- show the featured book cover without cropping by resizing the hero card layout
- add the missing book green palette and update hover styling so gradients render with the intended tones
- fix navigation and admin dashboard backgrounds to resolve dark-on-dark contrast issues
