### PR TITLE
Fix PDF worker configuration and refresh dashboard covers

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -7,6 +7,9 @@ import { useBooks } from '@/hooks/use-books';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { BookOpen } from 'lucide-react';
+import { resolveApiFileUrl } from '@/lib/asset-utils';
+
+const FALLBACK_COVER_IMAGE = '/book-placeholder.svg';
 
 export default function DashboardPage() {
     const { data: books, isLoading } = useBooks();
@@ -29,27 +32,60 @@ export default function DashboardPage() {
                     </div>
                 ) : (
                     <div className="grid gap-6 md:grid-cols-2">
-                        {(books ?? []).slice(0, 6).map(book => (
-                            <Card key={book.id} className="border-white/10 bg-white/5 backdrop-blur">
-                                <CardHeader>
-                                    <CardTitle className="flex items-center gap-2 text-lg text-white">
-                                        <BookOpen className="h-5 w-5 text-reading-accent" />
-                                        {book.title}
-                                    </CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-4 text-sm text-reading-text/80">
-                                    <p className="font-medium text-white/70">Autor: {book.author}</p>
-                                    <p className="line-clamp-3 text-sm text-reading-text/70">{book.description}</p>
-                                    <div className="flex items-center justify-between text-xs text-reading-text/60">
-                                        <span>{book.pages} strana</span>
-                                        <span>{book.isPremium ? 'Premium' : 'Besplatna'}</span>
-                                    </div>
-                                    <Button asChild className="w-full">
-                                        <Link href={`/reader/${book.id}`}>Čitaj</Link>
-                                    </Button>
-                                </CardContent>
-                            </Card>
-                        ))}
+                        {(books ?? []).slice(0, 6).map(book => {
+                            const coverUrl = book.coverImageUrl
+                                ? resolveApiFileUrl(book.coverImageUrl) ?? book.coverImageUrl
+                                : null;
+
+                            return (
+                                <Card
+                                    key={book.id}
+                                    className="group flex h-full flex-col border-white/10 bg-white/5 backdrop-blur transition duration-200 hover:border-library-gold/40"
+                                >
+                                    <CardHeader className="space-y-4">
+                                        <div className="relative">
+                                            <div className="absolute inset-0 scale-[0.96] rounded-[24px] bg-library-highlight/20 opacity-0 blur-xl transition group-hover:opacity-100" />
+                                            <div className="relative overflow-hidden rounded-[24px] border border-white/5 bg-white/10 shadow-lg">
+                                                {coverUrl ? (
+                                                    <img
+                                                        src={coverUrl}
+                                                        alt={`Naslovnica za ${book.title}`}
+                                                        className="h-48 w-full object-cover"
+                                                        loading="lazy"
+                                                        onError={event => {
+                                                            const target = event.currentTarget;
+                                                            if (!target.src.endsWith(FALLBACK_COVER_IMAGE)) {
+                                                                target.onerror = null;
+                                                                target.src = FALLBACK_COVER_IMAGE;
+                                                            }
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <div className="flex h-48 items-center justify-center bg-library-fog text-sm text-reading-text/60">
+                                                        Naslovnica u pripremi
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                        <CardTitle className="flex items-center gap-2 text-lg text-white">
+                                            <BookOpen className="h-5 w-5 text-reading-accent" />
+                                            {book.title}
+                                        </CardTitle>
+                                        <p className="font-medium text-white/70">Autor: {book.author}</p>
+                                    </CardHeader>
+                                    <CardContent className="flex flex-1 flex-col gap-4 text-sm text-reading-text/80">
+                                        <p className="line-clamp-3 text-sm text-reading-text/70">{book.description}</p>
+                                        <div className="flex items-center justify-between text-xs text-reading-text/60">
+                                            <span>{book.pages} strana</span>
+                                            <span>{book.isPremium ? 'Premium' : 'Besplatna'}</span>
+                                        </div>
+                                        <Button asChild className="mt-auto w-full">
+                                            <Link href={`/reader/${book.id}`}>Čitaj</Link>
+                                        </Button>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
                     </div>
                 )}
             </div>

--- a/frontend/src/components/reader/ReaderView.tsx
+++ b/frontend/src/components/reader/ReaderView.tsx
@@ -15,12 +15,18 @@ import {
 } from '@/hooks/use-reader';
 import { API_CONFIG } from '@/utils/constants';
 import { tokenManager } from '@/lib/api-client';
-import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist/types/src/display/api';
 import type { SecureStreamDescriptor } from '@/types/reader';
 
+let pdfWorkerSrc: string | null = null;
+
 const pdfjsLibPromise = import('pdfjs-dist').then(pdfjs => {
-    pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+    if (typeof window !== 'undefined') {
+        if (!pdfWorkerSrc) {
+            pdfWorkerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
+        }
+        pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerSrc;
+    }
     return pdfjs;
 });
 


### PR DESCRIPTION
## Summary
- resolve the pdf.js worker from the module URL so the secure reader loads without default export errors
- enhance the dashboard book cards to reuse the landing page cover presentation with fallbacks for missing images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee52db760832cb826cbb30d283b76