### PR TITLE
Fix reader route params handling and prevent PDF reload loop

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1,10 +1,12 @@
 import ReaderView from '@/components/reader/ReaderView';
 
 interface ReaderPageProps {
-    params: { bookId: string };
+    params: Promise<{ bookId: string }>;
 }
 
-export default function ReaderPage({ params }: ReaderPageProps) {
-    const bookId = Number(params.bookId);
-    return <ReaderView bookId={Number.isNaN(bookId) ? 0 : bookId} />;
+export default async function ReaderPage({ params }: ReaderPageProps) {
+    const { bookId } = await params;
+    const parsedBookId = Number(bookId);
+
+    return <ReaderView bookId={Number.isNaN(parsedBookId) ? 0 : parsedBookId} />;
 }


### PR DESCRIPTION
- await dynamic route params in the reader page to comply with Next.js async params requirements
- guard the reader view PDF loader against repeated fetch attempts that caused render loops when authorization failed
