### PR TITLE
Fix reader session loops and stabilize PDF loading

### DIFF
--- a/frontend/src/hooks/use-reader.ts
+++ b/frontend/src/hooks/use-reader.ts
@@ -23,6 +23,9 @@ export const useBookReadAccess = (bookId?: number) => {
         },
         enabled: typeof bookId === 'number' && bookId > 0,
         staleTime: 60 * 1000,
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
     });
 };
 


### PR DESCRIPTION
## Summary
- guard reading session start with explicit attempt tracking, book-change resets, and manual retry support to prevent infinite mutation loops in the reader view
- surface session and PDF loading errors with actionable retry controls and reset the viewer state when navigating between books to avoid repeated unauthorized fetches
- disable automatic refetches for the secure book access query so the PDF loader does not hammer the API after authorization failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfc105ab18832cb98296ba372fc4c5