### PR TITLE
Secure streaming sessions and improve PDF reader

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/service/BookServiceImpl.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/BookServiceImpl.java
@@ -250,8 +250,6 @@ public class BookServiceImpl implements BookService {
                     (book.getIsPremium() ? "premium" : "") + " book");
         }
 
-        incrementReadCount(bookId);
-
         log.info("User {} accessed book content: {} (ID: {})",
                 user.getEmail(), book.getTitle(), bookId);
 

--- a/backend/readify/src/main/java/me/remontada/readify/service/LocalFileStorageService.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/LocalFileStorageService.java
@@ -40,6 +40,12 @@ public class LocalFileStorageService implements FileStorageService {
     @Value("${app.storage.max-file-size:73400320}")
     private long maxFileSize;
 
+    @Value("${app.storage.max-pdf-size:${app.storage.max-file-size:73400320}}")
+    private long maxPdfSize;
+
+    @Value("${app.storage.max-image-size:5242880}")
+    private long maxImageSize;
+
     private Path booksPath;
     private Path coversPath;
 
@@ -93,6 +99,8 @@ public class LocalFileStorageService implements FileStorageService {
         if (!isImageFile(contentType)) {
             throw new IllegalArgumentException("Cover must be JPG or PNG image");
         }
+
+        validateImageFile(file);
 
         // Ekstrakcija ekstenzije
         String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
@@ -212,8 +220,9 @@ public class LocalFileStorageService implements FileStorageService {
             throw new IllegalArgumentException("File cannot be empty");
         }
 
-        if (file.getSize() > maxFileSize) {
-            throw new IllegalArgumentException("File size exceeds maximum allowed size");
+        long limit = Math.min(maxFileSize, maxPdfSize);
+        if (file.getSize() > limit) {
+            throw new IllegalArgumentException("File size exceeds maximum allowed size for PDF documents");
         }
 
         String contentType = file.getContentType();
@@ -231,6 +240,17 @@ public class LocalFileStorageService implements FileStorageService {
                         contentType.equals("image/jpg") ||
                         contentType.equals("image/png")
         );
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("File cannot be empty");
+        }
+
+        long limit = Math.min(maxFileSize, maxImageSize);
+        if (file.getSize() > limit) {
+            throw new IllegalArgumentException("Image size exceeds maximum allowed size");
+        }
     }
 
     /**

--- a/backend/readify/src/main/java/me/remontada/readify/service/StreamingSessionService.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/StreamingSessionService.java
@@ -1,0 +1,224 @@
+package me.remontada.readify.service;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import me.remontada.readify.model.Book;
+import me.remontada.readify.model.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * In-memory storage for short lived streaming sessions used to authorise PDF range requests.
+ *
+ * <p>The controller exposes a temporary token to the client which must be presented alongside a
+ * watermark signature for every chunk request. This service keeps track of the issued tokens,
+ * verifies that they belong to the expected user/book combination and prevents repeated read count
+ * increments for the same viewing session.</p>
+ */
+@Slf4j
+@Service
+public class StreamingSessionService {
+
+    private static final DateTimeFormatter WATERMARK_TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneOffset.UTC);
+
+    private final Duration sessionTtl;
+    private final byte[] hmacKey;
+    private final ConcurrentMap<String, StreamingSession> sessions = new ConcurrentHashMap<>();
+
+    public StreamingSessionService(
+            @Value("${app.streaming.session-ttl-seconds:7200}") long sessionTtlSeconds,
+            @Value("${app.streaming.watermark-secret:}") String watermarkSecret,
+            @Value("${readify.jwt.secret:readify-default-secret}") String fallbackSecret) {
+
+        if (sessionTtlSeconds <= 0) {
+            log.warn("Invalid streaming session TTL supplied ({}). Falling back to 2 hours.", sessionTtlSeconds);
+            sessionTtlSeconds = 7200;
+        }
+
+        this.sessionTtl = Duration.ofSeconds(sessionTtlSeconds);
+
+        String secretToUse = watermarkSecret != null && !watermarkSecret.isBlank()
+                ? watermarkSecret
+                : fallbackSecret;
+
+        if (secretToUse == null || secretToUse.isBlank()) {
+            throw new IllegalStateException("Watermark secret must not be empty");
+        }
+
+        this.hmacKey = secretToUse.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Generate a new streaming session for the supplied user and book combination.
+     */
+    public StreamingSessionDescriptor openSession(User user, Book book) {
+        Objects.requireNonNull(user, "User is required to open a streaming session");
+        Objects.requireNonNull(book, "Book is required to open a streaming session");
+
+        cleanupExpiredSessions();
+
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plus(sessionTtl);
+        String token = UUID.randomUUID().toString();
+
+        String watermarkText = buildWatermarkText(user, book, issuedAt);
+        String signature = computeSignature(user.getId(), book.getId(), token, issuedAt);
+
+        StreamingSession session = new StreamingSession(
+                token,
+                user.getId(),
+                book.getId(),
+                issuedAt,
+                expiresAt,
+                watermarkText,
+                signature
+        );
+
+        sessions.put(token, session);
+
+        return new StreamingSessionDescriptor(token, issuedAt, expiresAt, watermarkText, signature);
+    }
+
+    /**
+     * Validate that the token provided by the client is still active and belongs to the expected
+     * user/book pair. The watermark signature must also match to prevent token theft.
+     */
+    public Optional<StreamingSession> validateSession(String token,
+                                                      Long expectedUserId,
+                                                      Long expectedBookId,
+                                                      String providedSignature) {
+        if (token == null || token.isBlank()) {
+            return Optional.empty();
+        }
+
+        StreamingSession session = sessions.get(token);
+        if (session == null) {
+            return Optional.empty();
+        }
+
+        Instant now = Instant.now();
+        if (now.isAfter(session.getExpiresAt())) {
+            sessions.remove(token);
+            return Optional.empty();
+        }
+
+        if (!Objects.equals(expectedUserId, session.getUserId())
+                || !Objects.equals(expectedBookId, session.getBookId())) {
+            return Optional.empty();
+        }
+
+        if (providedSignature == null || providedSignature.isBlank()) {
+            return Optional.empty();
+        }
+
+        if (!session.getWatermarkSignature().equals(providedSignature)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(session);
+    }
+
+    /**
+     * Ensure that read count is incremented only once per streaming session.
+     */
+    public boolean markReadCountRegistered(String token) {
+        if (token == null) {
+            return false;
+        }
+
+        StreamingSession session = sessions.get(token);
+        if (session == null) {
+            return false;
+        }
+
+        return session.getReadCountRegistered().compareAndSet(false, true);
+    }
+
+    private void cleanupExpiredSessions() {
+        Instant now = Instant.now();
+        sessions.entrySet().removeIf(entry -> now.isAfter(entry.getValue().getExpiresAt()));
+    }
+
+    private String computeSignature(Long userId, Long bookId, String token, Instant issuedAt) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(hmacKey, "HmacSHA256"));
+            String payload = String.format("uid:%s|book:%s|token:%s|issued:%s",
+                    userId,
+                    bookId,
+                    token,
+                    issuedAt.toString());
+            byte[] digest = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to compute streaming watermark signature", e);
+        }
+    }
+
+    private String buildWatermarkText(User user, Book book, Instant issuedAt) {
+        String userDescriptor = String.format("%s (%s)", user.getFullName(), user.getEmail());
+        String timestamp = WATERMARK_TIMESTAMP_FORMAT.format(issuedAt);
+        return String.format("%s • %s • %s", userDescriptor, book.getTitle(), timestamp);
+    }
+
+    /**
+     * Descriptor returned to the client so that controllers can serialise streaming metadata
+     * without exposing the internal session state.
+     */
+    public record StreamingSessionDescriptor(
+            String token,
+            Instant issuedAt,
+            Instant expiresAt,
+            String watermarkText,
+            String watermarkSignature
+    ) {
+    }
+
+    /**
+     * Internal representation of an issued session token.
+     */
+    @Getter
+    public static final class StreamingSession {
+        private final String token;
+        private final Long userId;
+        private final Long bookId;
+        private final Instant issuedAt;
+        private final Instant expiresAt;
+        private final String watermarkText;
+        private final String watermarkSignature;
+        private final AtomicBoolean readCountRegistered = new AtomicBoolean(false);
+
+        private StreamingSession(String token,
+                                 Long userId,
+                                 Long bookId,
+                                 Instant issuedAt,
+                                 Instant expiresAt,
+                                 String watermarkText,
+                                 String watermarkSignature) {
+            this.token = token;
+            this.userId = userId;
+            this.bookId = bookId;
+            this.issuedAt = issuedAt;
+            this.expiresAt = expiresAt;
+            this.watermarkText = watermarkText;
+            this.watermarkSignature = watermarkSignature;
+        }
+    }
+}

--- a/frontend/src/components/admin/EditBookForm.tsx
+++ b/frontend/src/components/admin/EditBookForm.tsx
@@ -163,35 +163,17 @@ export function EditBookForm({ book }: EditBookFormProps) {
 
             // Upload novih fajlova ako postoje
             if (data.newPdfFile || data.newCoverFile) {
-                // Mora oba fajla za upload endpoint
-                const pdfFile = data.newPdfFile || await fetchExistingPdf(book.id);
-                const coverFile = data.newCoverFile || await fetchExistingCover(book.id);
-
-                if (pdfFile && coverFile) {
-                    await uploadFilesMutation.mutateAsync({
-                        bookId: book.id,
-                        pdfFile,
-                        coverFile
-                    });
-                }
+                await uploadFilesMutation.mutateAsync({
+                    bookId: book.id,
+                    ...(data.newPdfFile ? { pdfFile: data.newPdfFile } : {}),
+                    ...(data.newCoverFile ? { coverFile: data.newCoverFile } : {}),
+                });
             }
 
             router.push('/admin/books');
         } catch (error) {
             console.error('Error updating book:', error);
         }
-    };
-
-    // Helper funkcije za dohvatanje postojećih fajlova (ako treba)
-    const fetchExistingPdf = async (bookId: number): Promise<File | null> => {
-        // Ovo bi trebalo implementirati ako backend zahteva oba fajla
-        // Za sada vraćamo null
-        return null;
-    };
-
-    const fetchExistingCover = async (bookId: number): Promise<File | null> => {
-        // Isto kao gore
-        return null;
     };
 
     const getCoverUrl = () => {

--- a/frontend/src/hooks/use-books.ts
+++ b/frontend/src/hooks/use-books.ts
@@ -280,13 +280,21 @@ export function useUploadBookFiles() {
                                coverFile
                            }: {
             bookId: number;
-            pdfFile: File;
-            coverFile: File;
+            pdfFile?: File;
+            coverFile?: File;
         }) => {
+            if (!pdfFile && !coverFile) {
+                throw new Error('At least one file must be provided');
+            }
+
             const formData = new FormData();
             formData.append('bookId', bookId.toString());
-            formData.append('pdf', pdfFile);
-            formData.append('cover', coverFile);
+            if (pdfFile) {
+                formData.append('pdf', pdfFile);
+            }
+            if (coverFile) {
+                formData.append('cover', coverFile);
+            }
 
             const response = await client.post('/api/v1/files/upload', formData, {
                 headers: {


### PR DESCRIPTION
## Summary
- add a streaming session service to mint/verifiy temporary PDF tokens, personalize watermark metadata, and only increment read counts when streaming succeeds
- honor dedicated PDF/image size limits during storage validation
- let the reader delegate ranged fetching to pdf.js, draw the watermark onto each rendered page, and allow admins to replace either file independently

## Testing
- ⚠️ `./mvnw test` *(fails: unable to download parent POM because the network is unreachable)*
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cfc9194cc0832c893cbd413b5c7cdb