### PR TITLE
Fix reader streaming auth fallback

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/controller/BookController.java
+++ b/backend/readify/src/main/java/me/remontada/readify/controller/BookController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -333,11 +334,16 @@ public class BookController {
         try {
             Long bookId = book.getId();
             long contentLength = fileStorageService.getBookPdfSize(bookId);
-            String secureUrl = fileStorageService.generateSecureBookUrl(bookId, 2);
             StreamingSessionDescriptor session = streamingSessionService.openSession(user, book);
+            String secureUrl = fileStorageService.generateSecureBookUrl(bookId, 2);
+            String urlWithSession = UriComponentsBuilder.fromUriString(secureUrl)
+                    .queryParam("sessionToken", session.token())
+                    .queryParam("watermark", session.watermarkSignature())
+                    .build()
+                    .toUriString();
 
             Map<String, Object> stream = new HashMap<>();
-            stream.put("url", secureUrl);
+            stream.put("url", urlWithSession);
             stream.put("contentLength", contentLength);
             stream.put("chunkSize", pdfStreamingService.getChunkSize());
             stream.put("expiresAt", session.expiresAt().toString());

--- a/backend/readify/src/main/java/me/remontada/readify/controller/FileController.java
+++ b/backend/readify/src/main/java/me/remontada/readify/controller/FileController.java
@@ -122,7 +122,14 @@ public class FileController {
             }
 
             String sessionToken = headers.getFirst("X-Readify-Session");
+            if (sessionToken == null || sessionToken.isBlank()) {
+                sessionToken = request.getParameter("sessionToken");
+            }
+
             String providedSignature = headers.getFirst("X-Readify-Watermark");
+            if (providedSignature == null || providedSignature.isBlank()) {
+                providedSignature = request.getParameter("watermark");
+            }
 
             Optional<StreamingSession> sessionOpt = streamingSessionService.validateSession(
                     sessionToken,


### PR DESCRIPTION
## Summary
- add session token and watermark signature query parameters to the secure book streaming URL
- allow the file streaming endpoint to read session metadata from either headers or query parameters, so PDF.js requests stay authorized

## Testing
- ./mvnw test *(fails: dependency download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cff09aea3c832c9aa2fe244af64ef5