### PR TITLE
Support resilient streaming sessions

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/controller/BookController.java
+++ b/backend/readify/src/main/java/me/remontada/readify/controller/BookController.java
@@ -339,6 +339,7 @@ public class BookController {
             String urlWithSession = UriComponentsBuilder.fromUriString(secureUrl)
                     .queryParam("sessionToken", session.token())
                     .queryParam("watermark", session.watermarkSignature())
+                    .queryParam("issuedAt", session.issuedAt().toString())
                     .build()
                     .toUriString();
 
@@ -349,7 +350,8 @@ public class BookController {
             stream.put("expiresAt", session.expiresAt().toString());
             stream.put("headers", Map.of(
                     "X-Readify-Session", session.token(),
-                    "X-Readify-Watermark", session.watermarkSignature()
+                    "X-Readify-Watermark", session.watermarkSignature(),
+                    "X-Readify-Issued-At", session.issuedAt().toString()
             ));
 
             Map<String, Object> watermark = new HashMap<>();

--- a/frontend/src/components/reader/ReaderView.tsx
+++ b/frontend/src/components/reader/ReaderView.tsx
@@ -88,6 +88,7 @@ export function ReaderView({ bookId }: ReaderViewProps) {
     }, [data?.watermark?.text, user?.email]);
 
     const watermarkSignature = data?.watermark?.signature;
+    const watermarkIssuedAt = data?.watermark?.issuedAt;
 
     const clamp = useCallback((value: number, min: number, max: number) => {
         return Math.min(max, Math.max(min, value));
@@ -303,6 +304,14 @@ export function ReaderView({ bookId }: ReaderViewProps) {
                 headers['X-Readify-Watermark'] = watermarkHeader;
             }
 
+            const issuedAtHeader =
+                normalizedHeaderMap.get('x-readify-issued-at') ??
+                (headers['X-Readify-Issued-At'] as string | undefined) ??
+                watermarkIssuedAt;
+            if (issuedAtHeader) {
+                headers['X-Readify-Issued-At'] = issuedAtHeader;
+            }
+
             const rangeChunkSize =
                 typeof stream.chunkSize === 'number' && stream.chunkSize > 0
                     ? stream.chunkSize
@@ -310,7 +319,7 @@ export function ReaderView({ bookId }: ReaderViewProps) {
 
             return { requestUrl, headers, rangeChunkSize };
         },
-        [getAuthToken, watermarkSignature]
+        [getAuthToken, watermarkIssuedAt, watermarkSignature]
     );
 
     const refreshStreamingSession = useCallback(


### PR DESCRIPTION
- include issued-at metadata when generating secure book stream links
- allow the backend to rehydrate and validate streaming sessions using the issued-at timestamp
- forward the new issued-at header from the reader so range requests stay authorized

