### PR TITLE
Fix reader auth handling for PDF streaming

### DIFF
--- a/frontend/src/app/api/reader/[bookId]/content/route.ts
+++ b/frontend/src/app/api/reader/[bookId]/content/route.ts
@@ -236,7 +236,14 @@ const proxyPdfRequest = async (
     method: 'GET' | 'HEAD'
 ): Promise<NextResponse> => {
     const cookieStore = cookies();
-    const token = cookieStore.get(AUTH_CONFIG.TOKEN_KEY)?.value;
+    let token = cookieStore.get(AUTH_CONFIG.TOKEN_KEY)?.value;
+
+    if (!token) {
+        const authorization = request.headers.get('authorization');
+        if (authorization?.toLowerCase().startsWith('bearer ')) {
+            token = authorization.slice(7).trim();
+        }
+    }
 
     if (!token) {
         throw new ProxyError('Authentication required', 401);

--- a/frontend/src/components/reader/ReaderView.tsx
+++ b/frontend/src/components/reader/ReaderView.tsx
@@ -258,6 +258,11 @@ export function ReaderView({ bookId }: ReaderViewProps) {
                 Accept: 'application/pdf',
             };
 
+            const token = tokenManager.getToken();
+            if (token) {
+                headers.Authorization = `Bearer ${token}`;
+            }
+
             const requestUrl =
                 bookId > 0
                     ? `/api/reader/${bookId}/content`


### PR DESCRIPTION
- include the bearer token in reader PDF requests when one is available
- allow the reader proxy API route to accept bearer tokens from the Authorization header when no auth cookie is present

