### PR TITLE
Fix async access for reader content route

### DIFF
--- a/frontend/src/app/api/reader/[bookId]/content/route.ts
+++ b/frontend/src/app/api/reader/[bookId]/content/route.ts
@@ -235,7 +235,7 @@ const proxyPdfRequest = async (
     bookId: number,
     method: 'GET' | 'HEAD'
 ): Promise<NextResponse> => {
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     let token = cookieStore.get(AUTH_CONFIG.TOKEN_KEY)?.value;
 
     if (!token) {
@@ -308,10 +308,18 @@ const handleRequest = async (
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-export async function GET(request: NextRequest, context: { params: { bookId: string } }) {
-    return handleRequest(request, context.params, 'GET');
+export async function GET(
+    request: NextRequest,
+    context: { params: Promise<{ bookId: string }> }
+) {
+    const params = await context.params;
+    return handleRequest(request, params, 'GET');
 }
 
-export async function HEAD(request: NextRequest, context: { params: { bookId: string } }) {
-    return handleRequest(request, context.params, 'HEAD');
+export async function HEAD(
+    request: NextRequest,
+    context: { params: Promise<{ bookId: string }> }
+) {
+    const params = await context.params;
+    return handleRequest(request, params, 'HEAD');
 }


### PR DESCRIPTION
## Summary
- await cookies() when retrieving the auth token inside the reader content proxy
- resolve dynamic route params asynchronously before handling GET and HEAD requests

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d00b67bdd8832c8d48993d82edcc4c