### PR TITLE
Improve secure reader streaming auth propagation

### DIFF
--- a/frontend/src/app/api/reader/[bookId]/content/route.ts
+++ b/frontend/src/app/api/reader/[bookId]/content/route.ts
@@ -232,9 +232,12 @@ const forwardResponse = async (response: Response, method: 'GET' | 'HEAD') => {
 
 const extractAuthToken = async (request: NextRequest): Promise<string | null> => {
     const authorization = request.headers.get('authorization');
+    const explicitHeaderToken = request.headers.get('x-readify-auth');
     const headerToken = authorization?.toLowerCase().startsWith('bearer ')
         ? authorization.slice(7).trim()
         : null;
+
+    const searchParamsToken = request.nextUrl.searchParams.get('authToken');
 
     let cookieToken = request.cookies.get(AUTH_CONFIG.TOKEN_KEY)?.value ?? null;
 
@@ -243,12 +246,20 @@ const extractAuthToken = async (request: NextRequest): Promise<string | null> =>
         cookieToken = cookieStore.get(AUTH_CONFIG.TOKEN_KEY)?.value ?? null;
     }
 
+    if (explicitHeaderToken && explicitHeaderToken.trim().length > 0) {
+        return explicitHeaderToken.trim();
+    }
+
     if (cookieToken) {
         return cookieToken;
     }
 
     if (headerToken) {
         return headerToken;
+    }
+
+    if (searchParamsToken && searchParamsToken.trim().length > 0) {
+        return searchParamsToken.trim();
     }
 
     return null;

--- a/frontend/src/components/reader/ReaderView.tsx
+++ b/frontend/src/components/reader/ReaderView.tsx
@@ -258,9 +258,20 @@ export function ReaderView({ bookId }: ReaderViewProps) {
                 Accept: 'application/pdf',
             };
 
+            if (stream.headers && typeof stream.headers === 'object') {
+                for (const [key, value] of Object.entries(stream.headers)) {
+                    if (typeof value === 'string' && key) {
+                        headers[key] = value;
+                    }
+                }
+            }
+
             const token = tokenManager.getToken();
             if (token) {
                 headers.Authorization = `Bearer ${token}`;
+                if (bookId > 0) {
+                    headers['X-Readify-Auth'] = token;
+                }
             }
 
             const requestUrl =


### PR DESCRIPTION
## Summary
- ensure the reader client forwards secure stream headers and an explicit auth hint when requesting the proxy endpoint
- allow the reader proxy route to recover auth tokens from the custom header or query parameter as a fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d01aa877b0832c8912fcfc7c0293b1