### PR TITLE
Handle duplicate active reading sessions

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/repository/ReadingSessionRepository.java
+++ b/backend/readify/src/main/java/me/remontada/readify/repository/ReadingSessionRepository.java
@@ -10,12 +10,11 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ReadingSessionRepository extends JpaRepository<ReadingSession, Long> {
 
-    Optional<ReadingSession> findByUserAndBookAndSessionActiveTrue(User user, Book book);
+    List<ReadingSession> findByUserAndBookAndSessionActiveTrueOrderBySessionStartDesc(User user, Book book);
 
     List<ReadingSession> findByUserOrderByCreatedAtDesc(User user);
 


### PR DESCRIPTION
## Summary
- update the reading session repository to return all active sessions for a user/book pair
- guard startReadingSession from duplicate active sessions by returning the newest one and closing older duplicates

## Testing
- ./mvnw test *(fails: Unable to resolve Spring Boot parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07d500430832c906ba99859539dee