### PR TITLE
Fix admin user subscription badges showing no subscription

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/controller/SubscriptionController.java
+++ b/backend/readify/src/main/java/me/remontada/readify/controller/SubscriptionController.java
@@ -238,7 +238,7 @@ public class SubscriptionController {
             User currentUser = getCurrentUser(authentication);
             logger.info("Admin {} requesting all subscriptions", currentUser.getEmail());
 
-            List<Subscription> subscriptions = subscriptionService.getAllActiveSubscriptions();
+            List<Subscription> subscriptions = subscriptionService.getLatestSubscriptionsForAllUsers();
 
             List<SubscriptionResponseDTO> subscriptionDTOs = SubscriptionMapper.toResponseDTOList(subscriptions);
 

--- a/backend/readify/src/main/java/me/remontada/readify/repository/SubscriptionRepository.java
+++ b/backend/readify/src/main/java/me/remontada/readify/repository/SubscriptionRepository.java
@@ -49,6 +49,17 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     @Query("SELECT s FROM Subscription s WHERE s.user = :user ORDER BY s.createdAt DESC")
     List<Subscription> findByUserOrderByCreatedAtDesc(@Param("user") User user);
 
+    @Query("""
+            SELECT s FROM Subscription s
+            WHERE s.id IN (
+                SELECT MAX(s2.id)
+                FROM Subscription s2
+                GROUP BY s2.user.id
+            )
+            ORDER BY s.createdAt DESC
+            """)
+    List<Subscription> findLatestSubscriptionsForAllUsers();
+
     /**
      * Check if user has specific subscription type in history
      * Used to prevent multiple trials

--- a/backend/readify/src/main/java/me/remontada/readify/service/SubscriptionService.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/SubscriptionService.java
@@ -29,6 +29,8 @@ public interface SubscriptionService {
     // Admin functions
     List<Subscription> getAllActiveSubscriptions();
 
+    List<Subscription> getLatestSubscriptionsForAllUsers();
+
     long getActiveSubscriptionsCount();
 
     void expireOverdueSubscriptions();

--- a/backend/readify/src/main/java/me/remontada/readify/service/SubscriptionServiceImpl.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/SubscriptionServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -252,6 +253,20 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     public List<Subscription> getAllActiveSubscriptions() {
         logger.debug("Fetching all active subscriptions for admin");
         return subscriptionRepository.findByStatus(SubscriptionStatus.ACTIVE);
+    }
+
+    /**
+     * Get the most recent subscription for every user (admin function)
+     */
+    @Override
+    public List<Subscription> getLatestSubscriptionsForAllUsers() {
+        logger.debug("Fetching latest subscriptions for all users for admin view");
+        List<Subscription> subscriptions = subscriptionRepository.findLatestSubscriptionsForAllUsers();
+
+        subscriptions.sort(Comparator.comparing(Subscription::getCreatedAt,
+                Comparator.nullsLast(Comparator.naturalOrder())).reversed());
+
+        return subscriptions;
     }
 
     /**

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -83,7 +83,21 @@ export default function AdminUsersPage() {
     const subscriptionMap = useMemo(() => {
         const map = new Map<number, AdminSubscription>();
         subscriptionsData?.subscriptions.forEach((subscription) => {
-            map.set(subscription.userId, subscription);
+            if (subscription?.userId == null) return;
+
+            const existing = map.get(subscription.userId);
+
+            if (!existing) {
+                map.set(subscription.userId, subscription);
+                return;
+            }
+
+            const existingTimestamp = existing.createdAt ? new Date(existing.createdAt).getTime() : 0;
+            const currentTimestamp = subscription.createdAt ? new Date(subscription.createdAt).getTime() : 0;
+
+            if (currentTimestamp >= existingTimestamp) {
+                map.set(subscription.userId, subscription);
+            }
         });
         return map;
     }, [subscriptionsData?.subscriptions]);


### PR DESCRIPTION
## Summary
- expose the most recent subscription for every user from the admin subscriptions API instead of only active records
- add a repository helper and service method to fetch and order the latest subscription per user
- update the admin users page to retain the newest subscription when building the badge lookup map

## Testing
- ./mvnw test *(fails: unable to download parent POM because external network is unreachable)*
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d07d8b81d4832c9ec5ed31437ff18f