### PR TITLE
Fix reader proxy token precedence

### DIFF
--- a/frontend/src/app/api/reader/[bookId]/content/route.ts
+++ b/frontend/src/app/api/reader/[bookId]/content/route.ts
@@ -254,6 +254,16 @@ const extractAuthToken = async (request: NextRequest): Promise<string | null> =>
         return explicitHeaderToken;
     }
 
+    const headerToken = normalizeAuthToken(request.headers.get('authorization'));
+    if (headerToken) {
+        return headerToken;
+    }
+
+    const searchParamsToken = normalizeAuthToken(request.nextUrl.searchParams.get('authToken'));
+    if (searchParamsToken) {
+        return searchParamsToken;
+    }
+
     let cookieToken = normalizeAuthToken(request.cookies.get(AUTH_CONFIG.TOKEN_KEY)?.value ?? null);
 
     if (!cookieToken) {
@@ -263,16 +273,6 @@ const extractAuthToken = async (request: NextRequest): Promise<string | null> =>
 
     if (cookieToken) {
         return cookieToken;
-    }
-
-    const headerToken = normalizeAuthToken(request.headers.get('authorization'));
-    if (headerToken) {
-        return headerToken;
-    }
-
-    const searchParamsToken = normalizeAuthToken(request.nextUrl.searchParams.get('authToken'));
-    if (searchParamsToken) {
-        return searchParamsToken;
     }
 
     return null;


### PR DESCRIPTION
## Summary
- prefer authorization header and query string tokens before cookies in the reader proxy route
- ensure streaming requests always use the freshest access token when contacting the backend

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d119b30048832c9ce4f48a1ccc1614