### PR TITLE
Add simple PDF demo page

### DIFF
--- a/frontend/public/sample.pdf
+++ b/frontend/public/sample.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Mock PDF radi!)
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000059 00000 n 
+0000000114 00000 n 
+0000000235 00000 n 
+0000000320 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+383
+%%EOF

--- a/frontend/src/app/pdf-demo/page.tsx
+++ b/frontend/src/app/pdf-demo/page.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+
+export const metadata = {
+    title: 'PDF Demo | ReadBookHub',
+};
+
+export default function PdfDemoPage() {
+    return (
+        <div className="flex min-h-screen flex-col bg-reading-background text-reading-contrast">
+            <header className="border-b border-library-gold/20 bg-library-midnight/80 py-6">
+                <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6">
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.32em] text-library-gold/80">Demo prikaz</p>
+                        <h1 className="mt-2 font-display text-2xl font-semibold text-reading-contrast">
+                            Jednostavan prikaz PDF dokumenta
+                        </h1>
+                    </div>
+                    <Link
+                        href="/"
+                        className="rounded-full border border-library-gold/30 px-4 py-2 text-sm font-medium text-reading-contrast transition hover:border-library-gold hover:text-library-gold"
+                    >
+                        ← Nazad na početnu
+                    </Link>
+                </div>
+            </header>
+
+            <main className="flex flex-1 flex-col items-center px-4 py-10">
+                <div className="w-full max-w-5xl space-y-6">
+                    <p className="text-sm text-reading-contrast/80">
+                        Ova stranica služi kao jednostavan primer da proverimo da se PDF fajl uspešno učitava i da se kroz
+                        njega može listati. Dokument se učitava direktno iz javne fascikle aplikacije.
+                    </p>
+
+                    <div className="h-[75vh] w-full overflow-hidden rounded-xl border border-library-gold/20 shadow-lg">
+                        <iframe
+                            src="/sample.pdf"
+                            title="Primer PDF dokumenta"
+                            className="h-full w-full"
+                        />
+                    </div>
+
+                    <p className="text-xs text-reading-contrast/60">
+                        Ukoliko vidiš prikaz dokumenta iznad i možeš da ga skroluješ, PDF prikaz radi ispravno.
+                    </p>
+                </div>
+            </main>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add a static sample PDF asset that lives in the public folder
- create a /pdf-demo route that embeds the PDF in an iframe for quick manual verification

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1803ed99c832c92140be4a205a594