### PR TITLE
Add local storage PDF demo using backend stream

### DIFF
--- a/backend/readify/.gitignore
+++ b/backend/readify/.gitignore
@@ -55,6 +55,9 @@ storage/covers/
 !sample-*.png
 !test-*.pdf
 !test-*.jpg
+!storage/
+!storage/books/
+!storage/books/book-42.pdf
 
 ### Logs ###
 *.log

--- a/backend/readify/storage/books/book-42.pdf
+++ b/backend/readify/storage/books/book-42.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Mock PDF radi!)
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000059 00000 n 
+0000000114 00000 n 
+0000000235 00000 n 
+0000000320 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+383
+%%EOF

--- a/frontend/public/sample.pdf
+++ b/frontend/public/sample.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Mock PDF radi!)
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000059 00000 n 
+0000000114 00000 n 
+0000000235 00000 n 
+0000000320 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+383
+%%EOF

--- a/frontend/src/app/api/pdf-demo/local/[bookId]/route.ts
+++ b/frontend/src/app/api/pdf-demo/local/[bookId]/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest } from 'next/server';
+import { API_CONFIG } from '@/utils/constants';
+
+const FORWARDED_RESPONSE_HEADERS = new Set([
+    'content-type',
+    'content-length',
+    'content-range',
+    'accept-ranges',
+    'cache-control',
+    'content-disposition',
+]);
+
+const buildBackendUrl = (bookId: string) => {
+    const normalizedId = Number.parseInt(bookId, 10);
+
+    if (Number.isNaN(normalizedId) || normalizedId <= 0) {
+        throw new Error('Invalid book id');
+    }
+
+    return `${API_CONFIG.BASE_URL}/api/v1/files/demo/local/${normalizedId}`;
+};
+
+const copyHeaders = (source: Headers): Headers => {
+    const headers = new Headers();
+
+    source.forEach((value, key) => {
+        if (FORWARDED_RESPONSE_HEADERS.has(key.toLowerCase())) {
+            headers.set(key, value);
+        }
+    });
+
+    return headers;
+};
+
+const proxyRequest = async (method: 'GET' | 'HEAD', request: NextRequest, bookId: string) => {
+    let backendUrl: string;
+
+    try {
+        backendUrl = buildBackendUrl(bookId);
+    } catch (error) {
+        return new Response(JSON.stringify({
+            success: false,
+            message: 'Neispravan ID knjige u zahtevu.',
+        }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+        });
+    }
+
+    const headers = new Headers();
+    headers.set('Accept', 'application/pdf');
+
+    const rangeHeader = request.headers.get('range');
+    if (rangeHeader) {
+        headers.set('Range', rangeHeader);
+    }
+
+    const backendResponse = await fetch(backendUrl, {
+        method,
+        headers,
+        cache: 'no-store',
+        redirect: 'manual',
+    });
+
+    const responseHeaders = copyHeaders(backendResponse.headers);
+
+    if (backendResponse.headers.has('content-length')) {
+        responseHeaders.set('Content-Length', backendResponse.headers.get('content-length') as string);
+    }
+
+    if (backendResponse.headers.has('content-range')) {
+        responseHeaders.set('Content-Range', backendResponse.headers.get('content-range') as string);
+    }
+
+    if (!responseHeaders.has('Content-Type')) {
+        const fallbackType = backendResponse.headers.get('content-type') ?? 'application/pdf';
+        responseHeaders.set('Content-Type', fallbackType);
+    }
+
+    if (method === 'HEAD') {
+        return new Response(null, {
+            status: backendResponse.status,
+            headers: responseHeaders,
+        });
+    }
+
+    const body = backendResponse.body;
+
+    if (!body) {
+        const text = await backendResponse.text();
+        return new Response(text, {
+            status: backendResponse.status,
+            headers: responseHeaders,
+        });
+    }
+
+    return new Response(body, {
+        status: backendResponse.status,
+        headers: responseHeaders,
+    });
+};
+
+export async function GET(request: NextRequest, { params }: { params: { bookId: string } }) {
+    return proxyRequest('GET', request, params.bookId);
+}
+
+export async function HEAD(request: NextRequest, { params }: { params: { bookId: string } }) {
+    return proxyRequest('HEAD', request, params.bookId);
+}

--- a/frontend/src/app/pdf-demo/PdfViewerDemo.tsx
+++ b/frontend/src/app/pdf-demo/PdfViewerDemo.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { FormEvent, useMemo, useState } from 'react';
+
+const DEFAULT_BOOK_ID = 42;
+
+const sanitizeBookId = (raw: string): number | null => {
+    if (!raw) {
+        return null;
+    }
+
+    const normalized = Number.parseInt(raw, 10);
+
+    if (Number.isNaN(normalized) || normalized <= 0) {
+        return null;
+    }
+
+    return normalized;
+};
+
+interface PdfViewerDemoProps {
+    initialBookId?: number;
+}
+
+const PdfViewerDemo = ({ initialBookId = DEFAULT_BOOK_ID }: PdfViewerDemoProps) => {
+    const [inputValue, setInputValue] = useState(() => String(initialBookId));
+    const [activeBookId, setActiveBookId] = useState(initialBookId);
+    const [error, setError] = useState<string | null>(null);
+    const [refreshCounter, setRefreshCounter] = useState(0);
+
+    const viewerSrc = useMemo(() => `/api/pdf-demo/local/${activeBookId}?refresh=${refreshCounter}`, [activeBookId, refreshCounter]);
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const sanitized = sanitizeBookId(inputValue.trim());
+        if (sanitized === null) {
+            setError('Unesi ispravan ID knjige (pozitivan broj).');
+            return;
+        }
+
+        setActiveBookId(sanitized);
+        setRefreshCounter((counter) => counter + 1);
+        setError(null);
+    };
+
+    return (
+        <div className="space-y-6">
+            <form
+                onSubmit={handleSubmit}
+                className="flex flex-col gap-4 rounded-xl border border-library-gold/20 bg-library-midnight/40 p-5 shadow-sm"
+            >
+                <div>
+                    <label htmlFor="bookId" className="text-xs font-medium uppercase tracking-[0.32em] text-library-gold/70">
+                        ID knjige u lokalnom storage-u
+                    </label>
+                    <div className="mt-2 flex items-center gap-3">
+                        <input
+                            id="bookId"
+                            name="bookId"
+                            type="number"
+                            min={1}
+                            value={inputValue}
+                            onChange={(event) => setInputValue(event.target.value)}
+                            className="w-32 rounded-lg border border-library-gold/40 bg-library-midnight/60 px-3 py-2 text-sm text-reading-contrast focus:border-library-gold focus:outline-none"
+                        />
+                        <button
+                            type="submit"
+                            className="rounded-lg bg-library-gold px-4 py-2 text-sm font-medium text-library-midnight transition hover:bg-library-gold/80"
+                        >
+                            Učitaj PDF
+                        </button>
+                    </div>
+                    <p className="mt-2 text-xs text-reading-contrast/60">
+                        U storage fascikli backenda očekuje se fajl pod nazivom <code className="rounded bg-library-midnight/80 px-1">book-{'{ID}'}.pdf</code>.
+                    </p>
+                </div>
+                {error ? <p className="text-sm text-red-400">{error}</p> : null}
+            </form>
+
+            <div className="h-[75vh] w-full overflow-hidden rounded-xl border border-library-gold/20 shadow-lg">
+                <iframe key={`${activeBookId}-${refreshCounter}`} src={viewerSrc} title={`PDF za knjigu ${activeBookId}`} className="h-full w-full" />
+            </div>
+        </div>
+    );
+};
+
+export default PdfViewerDemo;

--- a/frontend/src/app/pdf-demo/page.tsx
+++ b/frontend/src/app/pdf-demo/page.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+
+import PdfViewerDemo from './PdfViewerDemo';
+
+export const metadata = {
+    title: 'PDF Demo | ReadBookHub',
+};
+
+export default function PdfDemoPage() {
+    return (
+        <div className="flex min-h-screen flex-col bg-reading-background text-reading-contrast">
+            <header className="border-b border-library-gold/20 bg-library-midnight/80 py-6">
+                <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6">
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.32em] text-library-gold/80">Demo prikaz</p>
+                        <h1 className="mt-2 font-display text-2xl font-semibold text-reading-contrast">
+                            Jednostavan prikaz PDF dokumenta
+                        </h1>
+                    </div>
+                    <Link
+                        href="/"
+                        className="rounded-full border border-library-gold/30 px-4 py-2 text-sm font-medium text-reading-contrast transition hover:border-library-gold hover:text-library-gold"
+                    >
+                        ← Nazad na početnu
+                    </Link>
+                </div>
+            </header>
+
+            <main className="flex flex-1 flex-col items-center px-4 py-10">
+                <div className="w-full max-w-5xl space-y-6">
+                    <p className="text-sm text-reading-contrast/80">
+                        Ova stranica služi kao sledeći korak – proveravamo da PDF fajl koji se nalazi u lokalnom storage-u
+                        backenda može da se učita kroz proxy rutu na frontendu. Ovo simulira način na koji će čitač u praksi
+                            dolaziti do fajla.
+                    </p>
+                    <PdfViewerDemo />
+
+                    <div className="rounded-xl border border-library-gold/10 bg-library-midnight/40 p-5 text-sm text-reading-contrast/80">
+                        <p>
+                            Za demonstraciju je spremljen fajl <code className="rounded bg-library-midnight/80 px-1">book-42.pdf</code>{' '}
+                            u <code className="rounded bg-library-midnight/80 px-1">backend/readify/storage/books</code>. Kada backend radi
+                            sa <code className="rounded bg-library-midnight/80 px-1">LocalFileStorageService</code>,
+                            demo endpoint <code className="rounded bg-library-midnight/80 px-1">/api/v1/files/demo/local/42</code>{' '}
+                            vraća taj PDF, a frontend ga prikazuje preko iframe-a.
+                        </p>
+                        <p className="mt-3 text-xs text-reading-contrast/60">
+                            Za druge ID vrednosti potrebno je da u istoj fascikli postoji odgovarajući fajl{' '}
+                            <code className="rounded bg-library-midnight/80 px-1">book-{'{ID}'}.pdf</code>.
+                        </p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- expose a `/api/v1/files/demo/local/{bookId}` endpoint to stream PDFs from the local backend storage when using the local file storage implementation
- proxy the demo endpoint through Next.js and add an interactive viewer so different book IDs can be tested from the UI
- check in a sample `book-42.pdf` file under the backend storage directory and adjust `.gitignore` so it is available for the demo
