### PR TITLE
Revamp promo chapters page and landing CTAs

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -89,7 +89,7 @@ export default function LandingPage() {
                             <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
                                 {/* Show different buttons based on authentication and subscription status */}
                                 {isAuthenticated && hasActiveSubscription ? (
-                                    // Authenticated with active subscription: Show "Otvori moju biblioteku" + "Istraži katalog"
+                                    // Authenticated with active subscription: Show "Otvori moju biblioteku" + "Istraži katalog" + "Promo poglavlja"
                                     <>
                                         <Button
                                             size="lg"
@@ -108,9 +108,18 @@ export default function LandingPage() {
                                         >
                                             Istraži katalog
                                         </Button>
+
+                                        <Button
+                                            size="lg"
+                                            variant="ghost"
+                                            onClick={() => router.push('/promo-chapters')}
+                                            className={cn(dt.interactive.buttonGhost, 'text-lg text-reading-contrast')}
+                                        >
+                                            Promo poglavlja
+                                        </Button>
                                     </>
                                 ) : isAuthenticated && !hasActiveSubscription ? (
-                                    // Authenticated WITHOUT active subscription: Show "Pogledaj planove" + "Istraži katalog"
+                                    // Authenticated WITHOUT active subscription: Show "Pogledaj planove" + "Pogledaj promo poglavlja"
                                     <>
                                         <Button
                                             size="lg"
@@ -127,11 +136,11 @@ export default function LandingPage() {
                                             onClick={() => router.push('/promo-chapters')}
                                             className={cn(dt.interactive.buttonSecondary, 'text-lg text-reading-contrast')}
                                         >
-                                            Istraži katalog
+                                            Pogledaj promo poglavlja
                                         </Button>
                                     </>
                                 ) : (
-                                    // Not authenticated: Show "Aktiviraj besplatnu probu" + "Istraži katalog"
+                                    // Not authenticated: Show "Aktiviraj besplatnu probu" + "Pogledaj promo poglavlja" + "Istraži katalog"
                                     <>
                                         <Button
                                             size="lg"
@@ -145,8 +154,17 @@ export default function LandingPage() {
                                         <Button
                                             size="lg"
                                             variant="outline"
-                                            onClick={handleBrowse}
+                                            onClick={() => router.push('/promo-chapters')}
                                             className={cn(dt.interactive.buttonSecondary, 'text-lg text-reading-contrast')}
+                                        >
+                                            Pogledaj promo poglavlja
+                                        </Button>
+
+                                        <Button
+                                            size="lg"
+                                            variant="ghost"
+                                            onClick={handleBrowse}
+                                            className={cn(dt.interactive.buttonGhost, 'text-lg text-reading-contrast')}
                                         >
                                             Istraži katalog
                                         </Button>

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -79,7 +79,7 @@ export const HeroSection = ({ topBook, isAuthenticated, isBooksLoading, hasActiv
                             <div className="flex flex-col gap-4 sm:flex-row">
                                 {/* Show different buttons based on authentication and subscription status */}
                                 {isAuthenticated && hasActiveSubscription ? (
-                                    // Authenticated with active subscription: Show "Nastavi čitanje" + "Pogledaj katalog"
+                                    // Authenticated with active subscription: Show "Nastavi čitanje" + "Pogledaj katalog" + "Promo poglavlja"
                                     <>
                                         <Button
                                             size="lg"
@@ -99,9 +99,18 @@ export const HeroSection = ({ topBook, isAuthenticated, isBooksLoading, hasActiv
                                             <BookOpen className="mr-2 h-5 w-5" />
                                             Pogledaj katalog
                                         </Button>
+
+                                        <Button
+                                            variant="ghost"
+                                            size="lg"
+                                            onClick={() => router.push('/promo-chapters')}
+                                            className={cn(dt.interactive.buttonGhost, 'text-lg')}
+                                        >
+                                            Promo poglavlja
+                                        </Button>
                                     </>
                                 ) : isAuthenticated && !hasActiveSubscription ? (
-                                    // Authenticated WITHOUT active subscription: Show "Pogledaj planove" + "Pogledaj katalog"
+                                    // Authenticated WITHOUT active subscription: Show "Pogledaj planove" + "Pogledaj promo poglavlja"
                                     <>
                                         <Button
                                             size="lg"
@@ -119,11 +128,11 @@ export const HeroSection = ({ topBook, isAuthenticated, isBooksLoading, hasActiv
                                             className={cn(dt.interactive.buttonSecondary, 'text-lg')}
                                         >
                                             <BookOpen className="mr-2 h-5 w-5" />
-                                            Pogledaj katalog
+                                            Pogledaj promo poglavlja
                                         </Button>
                                     </>
                                 ) : (
-                                    // Not authenticated: Show "Čitaj promo poglavlja" + "Registruj se"
+                                    // Not authenticated: Show "Čitaj promo poglavlja" + "Registruj se" + "Istraži katalog"
                                     <>
                                         <Button
                                             size="lg"
@@ -142,6 +151,15 @@ export const HeroSection = ({ topBook, isAuthenticated, isBooksLoading, hasActiv
                                             className={cn(dt.interactive.buttonSecondary, 'text-lg')}
                                         >
                                             Registruj se besplatno
+                                        </Button>
+
+                                        <Button
+                                            variant="ghost"
+                                            size="lg"
+                                            onClick={handleBrowse}
+                                            className={cn(dt.interactive.buttonGhost, 'text-lg')}
+                                        >
+                                            Istraži katalog
                                         </Button>
                                     </>
                                 )}

--- a/frontend/src/components/landing/ValuePropositionSection.tsx
+++ b/frontend/src/components/landing/ValuePropositionSection.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { Compass, Headphones, Layers, Sparkles, Users } from 'lucide-react';
+
 import { dt } from '@/lib/design-tokens';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
 interface ValuePropositionSectionProps {
     isAuthenticated: boolean;
@@ -29,6 +32,8 @@ const steps = [
 
 
 export const ValuePropositionSection = ({ isAuthenticated }: ValuePropositionSectionProps) => {
+    const router = useRouter();
+
     return (
         <section className="relative overflow-hidden border-y border-library-gold/15 bg-gradient-to-br from-library-fog via-library-parchment to-white">
             <div className="absolute -left-10 top-16 h-40 w-40 rounded-full border border-library-highlight/20 opacity-60 blur-2xl" />
@@ -74,6 +79,13 @@ export const ValuePropositionSection = ({ isAuthenticated }: ValuePropositionSec
                             <p className={cn(dt.typography.muted, 'mt-3')}>
                                 Pretplatom na našu platformu dobijate pristup svim dostupnim knjigama. Kliknite ovde za listu knjiga i njihova promo poglavlja.
                             </p>
+                            <Button
+                                size="lg"
+                                onClick={() => router.push('/promo-chapters')}
+                                className={cn(dt.interactive.buttonSecondary, 'mt-6 text-base')}
+                            >
+                                Pogledaj promo poglavlja
+                            </Button>
                         </div>
 
                         <div className="rounded-3xl border border-library-highlight/20 bg-white/85 p-8 shadow-[0_18px_60px_rgba(31,41,51,0.15)]">


### PR DESCRIPTION
- rebuild the public promo chapters page to mirror the library experience with filtering, pagination, and a pricing-focused hero section
- surface additional entry points to promo chapters across the landing page hero, value proposition section, and closing CTA
