### PR TITLE
Adjust promo chapter rate limit to five per day

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/service/PromoChapterRateLimitService.java
+++ b/backend/readify/src/main/java/me/remontada/readify/service/PromoChapterRateLimitService.java
@@ -14,13 +14,13 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * Rate limiting service for promo chapter access.
- * Limits anonymous users to 3 promo chapters per day by IP address.
+ * Limits anonymous users to 5 promo chapters per day by IP address.
  */
 @Slf4j
 @Service
 public class PromoChapterRateLimitService {
 
-    private static final int MAX_PROMO_CHAPTERS_PER_DAY = 3;
+    private static final int MAX_PROMO_CHAPTERS_PER_DAY = 5;
     private static final long CLEANUP_INTERVAL_HOURS = 6;
 
     private final ConcurrentMap<String, IpAccessTracker> ipTrackers = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Summary
- update the promo chapter rate limiting service to allow up to five anonymous reads per day
- keep promo chapter endpoints public so unauthenticated visitors can access the full promo flow

## Testing
- ./mvnw test *(fails: cannot connect to the configured PostgreSQL instance in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6351435d4832c825f67898344605f