### PR TITLE
Expand AI prompt support and unify loading screens

### DIFF
--- a/backend/readify/src/main/java/me/remontada/readify/dto/request/AiChatRequest.java
+++ b/backend/readify/src/main/java/me/remontada/readify/dto/request/AiChatRequest.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class AiChatRequest {
 
     @NotBlank(message = "Message is required")
-    @Size(max = 4000, message = "Message must not exceed 4000 characters")
+    @Size(max = 12000, message = "Message must not exceed 12000 characters")
     private String message;
 
     // Optional context from the book for better responses

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -11,6 +11,7 @@ import {
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { useAuth } from '@/hooks/useAuth';
 import { useDashboardAnalytics } from '@/hooks/use-dashboard-analytics';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 export default function AdminDashboardPage() {
     const { user } = useAuth();
@@ -84,7 +85,9 @@ export default function AdminDashboardPage() {
 
                 {isLoading ? (
                     <div className="flex items-center justify-center py-12">
-                        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-sky-950"></div>
+                        <div className="w-full max-w-md rounded-3xl bg-library-parchment/95 px-10 py-8 text-sky-950 shadow-inner">
+                            <LoadingSpinner size="lg" text="Učitavamo analitiku..." color="primary" />
+                        </div>
                     </div>
                 ) : analytics ? (
                     <>

--- a/frontend/src/app/book/[id]/page.tsx
+++ b/frontend/src/app/book/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useParams } from 'next/navigation';
 import { Star, ArrowLeft, Clock3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { PageLoader } from '@/components/ui/loading-spinner';
 import { dt } from '@/lib/design-tokens';
 import { resolveApiFileUrl } from '@/lib/asset-utils';
 import { useBook, usePopularBooks } from '@/hooks/use-books';
@@ -64,11 +64,7 @@ export default function BookDetailsPage() {
     };
 
     if (isBookLoading || isPopularLoading) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95">
-                <LoadingSpinner size="lg" text="Učitavanje detalja knjige..." />
-            </div>
-        );
+        return <PageLoader text="Učitavanje detalja knjige..." />;
     }
 
     if (!book) {

--- a/frontend/src/app/library/page.tsx
+++ b/frontend/src/app/library/page.tsx
@@ -21,7 +21,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { LoadingSpinner, PageLoader } from "@/components/ui/loading-spinner";
 import {
     Select,
     SelectContent,
@@ -192,11 +192,7 @@ export default function LibraryPage() {
     };
 
     if (isAuthLoading || !hasLibraryAccess) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-reading-background">
-                <LoadingSpinner size="lg" text="Pripremamo vašu biblioteku…" />
-            </div>
-        );
+        return <PageLoader text="Pripremamo vašu biblioteku…" />;
     }
 
     return (
@@ -360,7 +356,9 @@ export default function LibraryPage() {
 
                     {(isBooksLoading || isBooksFetching || isCategoriesLoading) && !books.length ? (
                         <div className="flex justify-center py-16">
-                            <LoadingSpinner size="lg" variant="book" text="Učitavamo naslove" />
+                            <div className="rounded-3xl bg-library-parchment/95 px-10 py-8 text-sky-950 shadow-inner">
+                                <LoadingSpinner size="lg" variant="book" text="Učitavamo naslove" color="primary" />
+                            </div>
                         </div>
                     ) : paginatedBooks.length ? (
                         <>

--- a/frontend/src/app/my-profile/page.tsx
+++ b/frontend/src/app/my-profile/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useUserSubscription } from '@/hooks/use-user-subscription';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { PageLoader } from '@/components/ui/loading-spinner';
 import { dt } from '@/lib/design-tokens';
 import { Calendar, CheckCircle, XCircle, Clock, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -64,11 +64,7 @@ export default function MyProfilePage() {
     const [isCanceling, setIsCanceling] = useState(false);
 
     if (authLoading || subLoading) {
-        return (
-            <div className={cn(dt.layouts.mainPage, "flex items-center justify-center bg-library-parchment/95")}>
-                <LoadingSpinner size="lg" variant="spinner" text="Učitavanje profila" />
-            </div>
-        );
+        return <PageLoader text="Učitavanje profila" />;
     }
 
     if (!user) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { HeroSection } from '@/components/landing/HeroSection';
 import { TopBooksSection } from '@/components/landing/TopBooksSection';
 import { ValuePropositionSection } from '@/components/landing/ValuePropositionSection';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { LoadingSpinner, PageLoader } from '@/components/ui/loading-spinner';
 import { Button } from '@/components/ui/button';
 import { dt } from '@/lib/design-tokens';
 import { useAuth } from '@/hooks/useAuth';
@@ -49,11 +49,7 @@ export default function LandingPage() {
     };
 
     if (isLoading) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-reading-background">
-                <LoadingSpinner size="lg" text="Pripremamo vašu biblioteku..." />
-            </div>
-        );
+        return <PageLoader text="Pripremamo vašu biblioteku..." />;
     }
 
     const currentYear = new Date().getFullYear();

--- a/frontend/src/app/promo-chapters/[id]/page.tsx
+++ b/frontend/src/app/promo-chapters/[id]/page.tsx
@@ -3,17 +3,13 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { PageLoader } from '@/components/ui/loading-spinner';
 import { PromoRateLimitDialog } from '@/components/promo/PromoRateLimitDialog';
 import { tokenManager } from '@/lib/api-client';
 
 const ReaderView = dynamic(() => import('@/components/reader/ReaderView'), {
     ssr: false,
-    loading: () => (
-        <div className="flex min-h-screen items-center justify-center bg-slate-950">
-            <LoadingSpinner size="lg" text="Učitavanje čitača..." />
-        </div>
-    ),
+    loading: () => <PageLoader text="Učitavanje čitača..." />,
 });
 
 interface RateLimitStatus {
@@ -117,44 +113,36 @@ export default function PromoChapterReaderPage() {
     }, [isAuthenticated]);
 
     if (isCheckingRateLimit) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-slate-950">
-                <LoadingSpinner size="lg" text="Provera dostupnosti..." />
-            </div>
-        );
+        return <PageLoader text="Provera dostupnosti..." />;
     }
 
     // If rate limit is reached, show the dialog and don't render the reader
     if (rateLimitStatus?.limitReached && !isAuthenticated) {
         return (
-            <div className="flex min-h-screen items-center justify-center bg-slate-950">
+            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
                 <PromoRateLimitDialog
                     open={showRateLimitDialog}
                     onOpenChange={setShowRateLimitDialog}
                     currentCount={rateLimitStatus.currentCount}
                     maxCount={rateLimitStatus.maxCount}
                 />
-                <div className="text-center text-slate-100">
-                    <p className="text-xl">Dnevni limit za promo poglavlja dostignut</p>
-                    <p className="mt-4 text-slate-400">Kreirajte besplatan nalog da nastavite</p>
+                <div className="text-center">
+                    <p className="text-xl font-semibold">Dnevni limit za promo poglavlja dostignut</p>
+                    <p className="mt-4 text-sky-950/70">Kreirajte besplatan nalog da nastavite</p>
                 </div>
             </div>
         );
     }
 
     if (isLoadingBook) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-slate-950">
-                <LoadingSpinner size="lg" text="Učitavanje knjige..." />
-            </div>
-        );
+        return <PageLoader text="Učitavanje knjige..." />;
     }
 
     if (!book) {
         return (
-            <div className="flex min-h-screen items-center justify-center bg-slate-950">
-                <div className="text-center text-slate-100">
-                    <p className="text-xl">Knjiga nije pronađena</p>
+            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
+                <div className="text-center">
+                    <p className="text-xl font-semibold">Knjiga nije pronađena</p>
                 </div>
             </div>
         );

--- a/frontend/src/app/promo-chapters/page.tsx
+++ b/frontend/src/app/promo-chapters/page.tsx
@@ -15,7 +15,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { LoadingSpinner, PageLoader } from '@/components/ui/loading-spinner';
 import {
     Select,
     SelectContent,
@@ -124,17 +124,13 @@ export default function PromoChaptersPage() {
     };
 
     if (isLoading && !books.length) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-reading-background">
-                <LoadingSpinner size="lg" text="Učitavamo promo poglavlja…" />
-            </div>
-        );
+        return <PageLoader text="Učitavamo promo poglavlja…" />;
     }
 
     if (error) {
         return (
-            <div className="flex min-h-screen items-center justify-center bg-reading-background">
-                <div className="rounded-3xl border border-destructive/30 bg-white/90 p-10 text-center text-destructive shadow-lg">
+            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
+                <div className="rounded-3xl border border-destructive/30 bg-white/90 p-10 text-center shadow-lg">
                     <p className="text-lg font-semibold">Došlo je do greške pri učitavanju promo poglavlja.</p>
                     <p className="mt-3 text-sm text-destructive/70">
                         Molimo pokušajte ponovo kasnije ili posetite našu stranicu sa planovima pretplate.
@@ -290,7 +286,9 @@ export default function PromoChaptersPage() {
 
                     {(isFetching && !books.length) ? (
                         <div className="flex justify-center py-16">
-                            <LoadingSpinner size="lg" variant="book" text="Učitavamo naslove" />
+                            <div className="rounded-3xl bg-library-parchment/95 px-10 py-8 text-sky-950 shadow-inner">
+                                <LoadingSpinner size="lg" variant="book" text="Učitavamo naslove" color="primary" />
+                            </div>
                         </div>
                     ) : paginatedBooks.length ? (
                         <>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -115,33 +115,37 @@ const ReaderBookPage: React.FC<ReaderPageProps> = ({ params }) => {
 
     if (isLoading || isFetching) {
         return (
-            <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
-                <LoadingSpinner size="lg" variant="book" text="Pripremamo vaš čitač…" />
-                <p className="text-sm text-muted-foreground">Proveravamo pristup i bezbednosne dozvole…</p>
+            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
+                <div className="flex flex-col items-center justify-center gap-4 text-center">
+                    <LoadingSpinner size="lg" variant="book" text="Pripremamo vaš čitač…" color="primary" />
+                    <p className="text-sm text-sky-950/70">Proveravamo pristup i bezbednosne dozvole…</p>
+                </div>
             </div>
         );
     }
 
     if (error) {
         return (
-            <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-                <AlertTriangle className="h-10 w-10 text-destructive" />
-                <div>
-                    <h1 className="text-lg font-semibold">Neuspešno učitavanje čitača</h1>
-                    <p className="mt-2 max-w-md text-sm text-muted-foreground">
-                        {(error as Error).message || "Došlo je do neočekivane greške."}
-                    </p>
-                </div>
-                <div className="flex flex-wrap items-center justify-center gap-3">
-                    <Button onClick={() => refetch()}>
-                        <RefreshCw className="mr-2 h-4 w-4" />
-                        Pokušaj ponovo
-                    </Button>
-                    <Button asChild variant="outline">
-                        <Link href="/library">
-                            <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na biblioteku
-                        </Link>
-                    </Button>
+            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
+                <div className="flex flex-col items-center justify-center gap-4 text-center">
+                    <AlertTriangle className="h-10 w-10 text-destructive" />
+                    <div>
+                        <h1 className="text-lg font-semibold">Neuspešno učitavanje čitača</h1>
+                        <p className="mt-2 max-w-md text-sm text-sky-950/70">
+                            {(error as Error).message || "Došlo je do neočekivane greške."}
+                        </p>
+                    </div>
+                    <div className="flex flex-wrap items-center justify-center gap-3">
+                        <Button onClick={() => refetch()}>
+                            <RefreshCw className="mr-2 h-4 w-4" />
+                            Pokušaj ponovo
+                        </Button>
+                        <Button asChild variant="outline">
+                            <Link href="/library">
+                                <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na biblioteku
+                            </Link>
+                        </Button>
+                    </div>
                 </div>
             </div>
         );
@@ -153,25 +157,27 @@ const ReaderBookPage: React.FC<ReaderPageProps> = ({ params }) => {
 
     if (!data.success || !data.canAccess) {
         return (
-            <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-                <AlertTriangle className="h-10 w-10 text-destructive" />
-                <div>
-                    <h1 className="text-lg font-semibold">Pristup nije dozvoljen</h1>
-                    <p className="mt-2 max-w-xl text-sm text-muted-foreground">
-                        {data.message || "Za pristup ovoj knjizi potrebna je aktivna pretplata."}
-                    </p>
-                </div>
-                {data.contentPreview && (
-                    <div className="max-w-2xl rounded-lg border border-dashed border-border bg-background/60 p-6 text-left text-sm text-muted-foreground">
-                        <h2 className="mb-2 text-lg font-semibold text-foreground">Pregled dostupnog sadržaja</h2>
-                        <p className="whitespace-pre-wrap leading-relaxed">{data.contentPreview}</p>
+            <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
+                <div className="flex flex-col items-center justify-center gap-4 text-center">
+                    <AlertTriangle className="h-10 w-10 text-destructive" />
+                    <div>
+                        <h1 className="text-lg font-semibold">Pristup nije dozvoljen</h1>
+                        <p className="mt-2 max-w-xl text-sm text-sky-950/70">
+                            {data.message || "Za pristup ovoj knjizi potrebna je aktivna pretplata."}
+                        </p>
                     </div>
-                )}
-                <Button asChild variant="outline">
-                    <Link href="/pricing">
-                        Pogledaj pretplate
-                    </Link>
-                </Button>
+                    {data.contentPreview && (
+                        <div className="max-w-2xl rounded-lg border border-dashed border-sky-900/20 bg-white/80 p-6 text-left text-sm text-sky-950/70">
+                            <h2 className="mb-2 text-lg font-semibold text-sky-950">Pregled dostupnog sadržaja</h2>
+                            <p className="whitespace-pre-wrap leading-relaxed">{data.contentPreview}</p>
+                        </div>
+                    )}
+                    <Button asChild variant="outline">
+                        <Link href="/pricing">
+                            Pogledaj pretplate
+                        </Link>
+                    </Button>
+                </div>
             </div>
         );
     }

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -17,7 +17,7 @@ import {
     X,
     Mail
 } from 'lucide-react';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { PageLoader } from '@/components/ui/loading-spinner';
 import { AuthGuard } from '@/components/auth/AuthGuard';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
@@ -162,9 +162,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
             requireAuth={true}
             roles={['ADMIN', 'MODERATOR']}
             fallback={
-                <div className="flex items-center justify-center min-h-screen">
-                    <LoadingSpinner size="lg" />
-                </div>
+                <PageLoader text="Učitavamo administratorski panel..." />
             }
         >
             <div className="flex min-h-screen bg-gray-50">

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth, useCan, useSubscription } from '@/hooks/useAuth';
-import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { LoadingSpinner, PageLoader } from '@/components/ui/loading-spinner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Shield, CreditCard, AlertTriangle } from 'lucide-react';
@@ -70,11 +70,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({
     }, [requireAuth, isLoading, isAuthenticated, redirectTo, fallback, router]);
 
     if (isLoading) {
-        return (
-            <div className="flex items-center justify-center min-h-screen">
-                <LoadingSpinner size="lg" />
-            </div>
-        );
+        return <PageLoader text="Proveravamo vaš nalog..." />;
     }
 
     if (requireAuth && !isAuthenticated) {
@@ -82,11 +78,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({
             return <>{fallback}</>;
         }
 
-        return (
-            <div className="flex min-h-screen items-center justify-center">
-                <LoadingSpinner size="lg" />
-            </div>
-        );
+        return <PageLoader text="Preusmeravanje na prijavu..." />;
     }
 
     if (roles.length > 0 && user) {

--- a/frontend/src/components/ui/loading-spinner.tsx
+++ b/frontend/src/components/ui/loading-spinner.tsx
@@ -166,14 +166,14 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
 };
 
 export const PageLoader: React.FC<{ text?: string }> = ({ text = "Loading..." }) => (
-    <div className="flex items-center justify-center min-h-screen bg-library-parchment/95">
-        <LoadingSpinner size="lg" variant="spinner" text={text} />
+    <div className="flex min-h-screen items-center justify-center bg-library-parchment/95 text-sky-950">
+        <LoadingSpinner size="lg" variant="spinner" text={text} color="primary" />
     </div>
 );
 
 export const ComponentLoader: React.FC<{ text?: string }> = ({ text }) => (
-    <div className="flex items-center justify-center py-8 bg-library-parchment/95">
-        <LoadingSpinner size="md" variant="spinner" text={text} />
+    <div className="flex items-center justify-center bg-library-parchment/95 py-8 text-sky-950">
+        <LoadingSpinner size="md" variant="spinner" text={text} color="primary" />
     </div>
 );
 


### PR DESCRIPTION
- allow larger AI chat payloads and extend the assistant request timeout with clearer messaging for slow responses
- standardize page-level loading states with the library parchment background and sky text across landing, reader, promo chapter, library, profile, book detail, auth guard, and admin dashboard views
- update shared loader helpers so downstream screens consistently inherit the new palette