### PR TITLE
Enable AI chat in promo chapter reader

### DIFF
--- a/frontend/src/components/reader/ReaderView.tsx
+++ b/frontend/src/components/reader/ReaderView.tsx
@@ -69,7 +69,7 @@ export interface ReaderViewProps {
     onPageChange?: (page: number) => void;
     className?: string;
     skipMetadata?: boolean; // Skip metadata fetch for public content (promo chapters)
-    isPromoChapter?: boolean; // Hide AI chat and bookmarks for promo chapters
+    isPromoChapter?: boolean; // Hide bookmarks for promo chapters
 }
 
 type PdfSource = DocumentProps["file"] | null;
@@ -1324,8 +1324,8 @@ const ReaderViewComponent: React.FC<ReaderViewProps> = ({
                 </aside>
             </div>
 
-            {/* AI Chat Panel - hidden for promo chapters */}
-            {!isPromoChapter && <AiChatPanel bookId={bookId} bookTitle={bookTitle} />}
+            {/* AI Chat Panel */}
+            <AiChatPanel bookId={bookId} bookTitle={bookTitle} />
         </div>
     );
 };


### PR DESCRIPTION
- allow the reader to always render the AI chat panel so promo chapters get the same assistant access as full books
- clarify the promo reader prop comment now that only bookmark controls are hidden