### PR TITLE
Revert "Fix PDF wasm fallback and tone down devtools detection"

### DIFF
--- a/frontend/src/components/reader/ReaderView.tsx
+++ b/frontend/src/components/reader/ReaderView.tsx
@@ -43,12 +43,6 @@ import { useAuth } from "@/hooks/useAuth";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 
-const PDFJS_DIST_VERSION = "5.3.93" as const;
-const DEFAULT_PDF_WORKER_SRC = `https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/build/pdf.worker.min.mjs` as const;
-const DEFAULT_PDF_WASM_URL = `https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/build/pdf.wasm` as const;
-const DEFAULT_PDF_CMAP_URL = `https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/cmaps/` as const;
-const DEFAULT_PDF_STANDARD_FONT_URL = `https://unpkg.com/pdfjs-dist@${PDFJS_DIST_VERSION}/standard_fonts/` as const;
-
 const MIN_SCALE = 0.75;
 const MAX_SCALE = 2.5;
 const SCALE_STEP = 0.25;
@@ -253,10 +247,7 @@ const ReaderViewComponent: React.FC<ReaderViewProps> = ({
 
         const configurePdfWorker = async () => {
             const { pdfjs } = await import("react-pdf");
-            const workerSrc = process.env.NEXT_PUBLIC_PDF_WORKER_URL?.trim();
-            pdfjs.GlobalWorkerOptions.workerSrc = workerSrc && workerSrc.length > 0
-                ? workerSrc
-                : DEFAULT_PDF_WORKER_SRC;
+            pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@5.3.93/build/pdf.worker.min.mjs`;
             setPdfjsLib(pdfjs);
         };
 
@@ -690,14 +681,20 @@ const ReaderViewComponent: React.FC<ReaderViewProps> = ({
 
     const baseDocumentOptions = useMemo(() => {
         const options: DocumentProps["options"] = {};
-        const cMapUrl = process.env.NEXT_PUBLIC_PDF_CMAP_URL?.trim() || DEFAULT_PDF_CMAP_URL;
-        const standardFontDataUrl = process.env.NEXT_PUBLIC_PDF_STANDARD_FONT_URL?.trim() || DEFAULT_PDF_STANDARD_FONT_URL;
-        const wasmUrl = process.env.NEXT_PUBLIC_PDF_WASM_URL?.trim() || DEFAULT_PDF_WASM_URL;
+        const cMapUrl = process.env.NEXT_PUBLIC_PDF_CMAP_URL;
+        const standardFontDataUrl = process.env.NEXT_PUBLIC_PDF_STANDARD_FONT_URL;
+        const wasmUrl = process.env.NEXT_PUBLIC_PDF_WASM_URL;
 
-        options.cMapUrl = cMapUrl;
-        options.cMapPacked = true;
-        options.standardFontDataUrl = standardFontDataUrl;
-        options.wasmUrl = wasmUrl;
+        if (cMapUrl) {
+            options.cMapUrl = cMapUrl;
+            options.cMapPacked = true;
+        }
+        if (standardFontDataUrl) {
+            options.standardFontDataUrl = standardFontDataUrl;
+        }
+        if (wasmUrl) {
+            options.wasmUrl = wasmUrl;
+        }
 
         return Object.keys(options).length ? options : undefined;
     }, []);

--- a/frontend/src/hooks/useDownloadPrevention.ts
+++ b/frontend/src/hooks/useDownloadPrevention.ts
@@ -8,7 +8,6 @@ export const useDownloadPrevention = (isEnabled: boolean = true) => {
     if (!isEnabled) return;
 
     let devToolsOpen = false;
-    const isProduction = process.env.NODE_ENV === 'production';
 
     // Disable right-click context menu
     const disableContextMenu = (e: MouseEvent) => {
@@ -75,11 +74,6 @@ export const useDownloadPrevention = (isEnabled: boolean = true) => {
 
     // Detect developer tools opening (basic detection)
     const detectDevTools = () => {
-      if (!isProduction) {
-        // Skip invasive devtools detection in non-production environments
-        return () => undefined;
-      }
-
       const threshold = 160;
 
       // Check if window is resized to accommodate dev tools
@@ -97,7 +91,7 @@ export const useDownloadPrevention = (isEnabled: boolean = true) => {
       };
 
       // Monitor console access attempts
-      const consoleLog = console.log;
+      let consoleLog = console.log;
       console.log = function(...args) {
         if (!devToolsOpen) {
           devToolsOpen = true;


### PR DESCRIPTION
- restore the previous PDF.js worker configuration that always uses the hosted worker script and only applies optional URLs when provided
- revert the relaxed download prevention logic so devtools detection runs in all environments
